### PR TITLE
Use Level.cell() instead of direct calculation

### DIFF
--- a/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/levels/PredesignedLevel.java
+++ b/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/levels/PredesignedLevel.java
@@ -111,7 +111,7 @@ public class PredesignedLevel extends CustomLevel {
 			int x, y;	// Calculate cell ID from coordinates
 			x = compassTargetCoordinates.getInt(0);
 			y = compassTargetCoordinates.getInt(1);
-			compassTarget = y * width + x;
+			compassTarget = cell(x, y);
 		}
 	}
 


### PR DESCRIPTION
As @Mikhael-Danilov stated at https://github.com/NYRDS/pixel-dungeon-remix/pull/28, direct calculation involving x,y coordinates shouldn't be done. We both missed this line so it got into the pull request.

Fixing.