### PR TITLE
Add a "you now have scroll X" when inscribing + small fix

### DIFF
--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/Stylus.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/Stylus.java
@@ -113,6 +113,7 @@ public class Stylus extends Item {
 		
 		Scroll inscribedScroll = Scroll.createRandomScroll();
 		getCurUser().collect(inscribedScroll);
+		GLog.i(Hero.TXT_YOU_NOW_HAVE, inscribedScroll.name());	// Let know which scroll was inscribed
 	}
 	
 	@Override

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/Stylus.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/Stylus.java
@@ -57,7 +57,7 @@ public class Stylus extends Item {
 	
 	@Override
 	public void execute( Hero hero, String action ) {
-		if (action == AC_INSCRIBE) {
+		if (action.equals(AC_INSCRIBE)) {
 
 			setCurUser(hero);
 			GameScene.selectItem( itemSelector, WndBag.Mode.INSCRIBABLE, TXT_SELECT_ARMOR );


### PR DESCRIPTION
Two things in this PR:

1. When inscribing, there is no message, so if a player has many scrolls, he will have hard time knowing what exactly he inscribed. So This adds a log message to help with that, making it look as if the player collected the newly inscribed scroll.
2. The same file `Stylus.java` had `action == AC_INSCRIBE` for string comparison, which is replaced by `action.equals()` for correctness.