### PR TITLE
Fix static string fields, part of #37

### DIFF
--- a/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/items/chaos/ChaosCrystal.java
+++ b/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/items/chaos/ChaosCrystal.java
@@ -27,7 +27,6 @@ public class ChaosCrystal extends UsableArtifact implements IChaosItem {
 	private static final float TIME_TO_USE = 1;
 
 	private static final String AC_FUSE             = "ChaosCrystal_Fuse";
-	private static final String TXT_SELECT_FOR_FUSE = Game.getVar(R.string.ChaosCrystal_SelectForFuse);
 
 	private static final int CHAOS_CRYSTALL_IMAGE = 9;
 	private static final float TIME_TO_FUSE = 10;
@@ -125,7 +124,7 @@ public class ChaosCrystal extends UsableArtifact implements IChaosItem {
 	};
 
 	private void fuse(Hero hero) {
-		GameScene.selectItem(itemSelector, WndBag.Mode.FUSEABLE, TXT_SELECT_FOR_FUSE);
+		GameScene.selectItem(itemSelector, WndBag.Mode.FUSEABLE, Game.getVar(R.string.ChaosCrystal_SelectForFuse));
 		hero.getSprite().operate(hero.getPos());
 	}
 

--- a/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/items/common/armor/NecromancerArmor.java
+++ b/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/items/common/armor/NecromancerArmor.java
@@ -15,8 +15,6 @@ import com.watabou.pixeldungeon.utils.GLog;
 public class NecromancerArmor extends ClassArmor {
 
 
-	private static final String TXT_NOT_NECROMANCER = Game.getVar(R.string.NecromancerArmor_NotNecromancer);
-
 	public NecromancerArmor() {
 		image = 22;
 	}
@@ -47,7 +45,7 @@ public class NecromancerArmor extends ClassArmor {
 		if (hero.heroClass == HeroClass.NECROMANCER) {
 			return super.doEquip( hero );
 		} else {
-			GLog.w( TXT_NOT_NECROMANCER );
+			GLog.w( Game.getVar(R.string.NecromancerArmor_NotNecromancer) );
 			return false;
 		}
 	}

--- a/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/items/common/armor/NecromancerRobe.java
+++ b/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/items/common/armor/NecromancerRobe.java
@@ -9,8 +9,6 @@ import com.watabou.pixeldungeon.utils.GLog;
 
 public class NecromancerRobe extends Armor {
 
-	private static final String TXT_NOT_NECROMANCER = Game.getVar(R.string.NecromancerArmor_NotNecromancer);
-
 	public String desc() {
 		return info2;
 	}
@@ -25,7 +23,7 @@ public class NecromancerRobe extends Armor {
 		if (hero.heroClass == HeroClass.NECROMANCER) {
 			return super.doEquip( hero );
 		} else {
-			GLog.w( TXT_NOT_NECROMANCER );
+			GLog.w( Game.getVar(R.string.NecromancerArmor_NotNecromancer) );
 			return false;
 		}
 	}

--- a/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/items/necropolis/BlackSkull.java
+++ b/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/items/necropolis/BlackSkull.java
@@ -20,9 +20,6 @@ public class BlackSkull extends Artifact {
 
 	private static final String CHARGE_KEY      = "charge";
 	private static final String ACTIVATED_KEY   = "activated";
-	private static final String TXT_SKULL_ACTIVATED = Game.getVar(R.string.BlackSkull_Activated);
-	private static final String TXT_SKULL_DEACTIVATED = Game.getVar(R.string.BlackSkull_Deactivated);
-	private static final String TXT_SKULL_RESSURRECT = Game.getVar(R.string.BlackSkull_Ressurrect);
 
 	private boolean activated = false;
 
@@ -44,16 +41,16 @@ public class BlackSkull extends Artifact {
 		if (mob.canBePet()) {
 			if (activated) {
 				mob.ressurrect(hero);
-				GLog.w( TXT_SKULL_RESSURRECT );
+				GLog.w( Game.getVar(R.string.BlackSkull_Ressurrect) );
 				charge = charge - RESSURRECTION_COST;
 				if (charge <= 0) {
-					GLog.w( TXT_SKULL_DEACTIVATED );
+					GLog.w( Game.getVar(R.string.BlackSkull_Deactivated) );
 					activated = false;
 				}
 			} else {
 				charge++;
 				if (charge >= MAXIMUM_CHARGE) {
-					GLog.w( TXT_SKULL_ACTIVATED );
+					GLog.w( Game.getVar(R.string.BlackSkull_Activated) );
 					activated = true;
 				}
 			}

--- a/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mechanics/spells/Spell.java
+++ b/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mechanics/spells/Spell.java
@@ -18,8 +18,6 @@ import com.watabou.pixeldungeon.utils.GLog;
 import com.watabou.pixeldungeon.utils.Utils;
 
 public class Spell {
-    private static final String TXT_NOT_ENOUGH_SOULS = Game.getVar(R.string.Spells_NotEnoughSP);
-    private static final String TXT_SELECT_CELL      = Game.getVar(R.string.Spell_SelectACell);
 
     protected      int level             = 1;
     protected      int spellCost         = 5;
@@ -51,7 +49,7 @@ public class Spell {
 
             if (!hero.enoughSP(spellCost())) {
                 if(reallyCast) {
-                    GLog.w(Utils.format(TXT_NOT_ENOUGH_SOULS, name));
+                    GLog.w(Utils.format(Game.getVar(R.string.Spells_NotEnoughSP), name));
                 }
                 return false;
             }
@@ -89,7 +87,7 @@ public class Spell {
 
                     @Override
                     public String prompt() {
-                        return TXT_SELECT_CELL;
+                        return Game.getVar(R.string.Spell_SelectACell);
                     }
                 });
                 return false;

--- a/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mechanics/spells/SummoningSpell.java
+++ b/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mechanics/spells/SummoningSpell.java
@@ -26,10 +26,7 @@ public class SummoningSpell extends Spell {
 
     private int summonLimit = 1;
 
-
-    private static final String TXT_MAXIMUM_PETS  	   = Game.getVar(R.string.Spells_SummonLimitReached);
-
-	protected String mobKind = "Rat";
+    protected String mobKind = "Rat";
 
     @Override
     public boolean canCast(@NonNull Char chr, boolean reallyCast) {
@@ -99,7 +96,7 @@ public class SummoningSpell extends Spell {
     }
 
     private String getLimitWarning(int limit){
-        return Utils.format(TXT_MAXIMUM_PETS, this.name(), limit);
+        return Utils.format(Game.getVar(R.string.Spells_SummonLimitReached), this.name(), limit);
     }
 
     public int getSummonLimit() {

--- a/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mobs/common/ShadowLord.java
+++ b/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mobs/common/ShadowLord.java
@@ -38,9 +38,6 @@ public class ShadowLord extends Boss implements IZapper {
 
 	private static final String LEVELCREATED   = "levelCreated";
 
-	private static final String TXT_INTRO = Game.getVar(R.string.ShadowLord_Intro);
-	private static final String TXT_DENY = Game.getVar(R.string.ShadowLord_Death);
-
 	public ShadowLord() {
 		hp(ht(260));
 		defenseSkill = 40;
@@ -181,7 +178,7 @@ public class ShadowLord extends Boss implements IZapper {
 					spawnShadow();
 				}
 
-				yell(TXT_INTRO);
+				yell(Game.getVar(R.string.ShadowLord_Intro));
 			}
 		}
 
@@ -216,7 +213,7 @@ public class ShadowLord extends Boss implements IZapper {
 	@Override
 	public void die(Object cause) {
 		super.die(cause);
-		yell(TXT_DENY);
+		yell(Game.getVar(R.string.ShadowLord_Death));
 		Tools.makeEmptyLevel(Dungeon.level);
 		Badges.validateBossSlain(Badges.Badge.SHADOW_LORD_SLAIN);
 	}

--- a/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mobs/icecaves/KoboldIcemancer.java
+++ b/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mobs/icecaves/KoboldIcemancer.java
@@ -20,9 +20,6 @@ import com.watabou.utils.Random;
 
 public class KoboldIcemancer extends Mob implements IZapper {
 
-	private static final String TXT_ICEBOLT_KILLED = Game
-			.getVar(R.string.KoboldIcemancer_Killed);
-
 	public KoboldIcemancer() {
 		hp(ht(70));
 		defenseSkill = 18;
@@ -69,7 +66,7 @@ public class KoboldIcemancer extends Mob implements IZapper {
 			if (!enemy.isAlive() && enemy == Dungeon.hero) {
 				Dungeon.fail(Utils.format(ResultDescriptions.MOB,
 						Utils.indefinite(getName()), Dungeon.depth));
-				GLog.n(TXT_ICEBOLT_KILLED, getName());
+				GLog.n(Game.getVar(R.string.KoboldIcemancer_Killed), getName());
 			}
 			return true;
 		}

--- a/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mobs/npc/AzuterronNPC.java
+++ b/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mobs/npc/AzuterronNPC.java
@@ -26,10 +26,6 @@ import java.util.Set;
 
 public class AzuterronNPC extends NPC {
 
-	private static final String TXT_QUEST_START = Game.getVar(R.string.AzuterronNPC_Quest_Start);
-	private static final String TXT_QUEST_END = Game.getVar(R.string.AzuterronNPC_Quest_End);
-	private static final String TXT_QUEST = Game.getVar(R.string.AzuterronNPC_Quest_Reminder);
-	
 	public AzuterronNPC() {
 		movable = false;
 	}
@@ -108,18 +104,18 @@ public class AzuterronNPC extends NPC {
 				Item reward = new PotionOfMight();
 
 				if (reward.doPickUp( Dungeon.hero )) {
-					GLog.i( Hero.TXT_YOU_NOW_HAVE, reward.name() );
+					GLog.i( Hero.getHeroYouNowHave(), reward.name() );
 				} else {
 					Dungeon.level.drop(reward, hero.getPos()).sprite.drop();
 				}
 				Quest.complete();
-				GameScene.show( new WndQuest( this, TXT_QUEST_END ) );
+				GameScene.show( new WndQuest( this, Game.getVar(R.string.AzuterronNPC_Quest_End) ) );
 			} else {
-				GameScene.show( new WndQuest( this, TXT_QUEST ) );
+				GameScene.show( new WndQuest( this, Game.getVar(R.string.AzuterronNPC_Quest_Reminder) ) );
 			}
 			
 		} else {
-			GameScene.show( new WndQuest( this, TXT_QUEST_START ) );
+			GameScene.show( new WndQuest( this, Game.getVar(R.string.AzuterronNPC_Quest_Start) ) );
 			Quest.given = true;
 			Quest.process();
 			Journal.add( Journal.Feature.AZUTERRON.desc() );

--- a/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mobs/npc/BellaNPC.java
+++ b/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mobs/npc/BellaNPC.java
@@ -8,8 +8,6 @@ import com.watabou.pixeldungeon.windows.WndQuest;
 
 public class BellaNPC extends ImmortalNPC {
 
-	private static final String TXT_MESSAGE = Game.getVar(R.string.BellaNPC_Message);
-
 	public BellaNPC() {
 	}
 
@@ -17,7 +15,7 @@ public class BellaNPC extends ImmortalNPC {
 	public boolean interact(final Hero hero) {
 		getSprite().turnTo( getPos(), hero.getPos() );
 
-		GameScene.show(new WndQuest(this, TXT_MESSAGE));
+		GameScene.show(new WndQuest(this, Game.getVar(R.string.BellaNPC_Message)));
 		return true;
 	}
 }

--- a/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mobs/npc/CagedKobold.java
+++ b/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mobs/npc/CagedKobold.java
@@ -23,15 +23,7 @@ import com.watabou.utils.Random;
 
 public class CagedKobold extends ImmortalNPC {
 
-	private static final String TXT_QUEST_START = Game.getVar(R.string.CagedKobold_Intro);
-	private static final String TXT_QUEST_END = Game.getVar(R.string.CagedKobold_Quest_End);
-	private static final String TXT_MESSAGE1 = Game.getVar(R.string.CagedKobold_Message1);
-	private static final String TXT_MESSAGE2 = Game.getVar(R.string.CagedKobold_Message2);
-	private static final String TXT_MESSAGE3 = Game.getVar(R.string.CagedKobold_Message3);
-
 	private static boolean spawned;
-
-	private static String[] TXT_PHRASES = {TXT_MESSAGE1, TXT_MESSAGE2, TXT_MESSAGE3};
 
 	public CagedKobold() {
 		IMMUNITIES.add( Paralysis.class );
@@ -83,18 +75,24 @@ public class CagedKobold extends ImmortalNPC {
 					Dungeon.level.drop(reward, hero.getPos()).sprite.drop();
 				}
 				Quest.complete();
-				GameScene.show( new WndQuest( this, TXT_QUEST_END ) );
+				GameScene.show( new WndQuest( this, Game.getVar(R.string.CagedKobold_Quest_End) ) );
 
 				CellEmitter.get( getPos() ).start( Speck.factory( Speck.LIGHT ), 0.2f, 3 );
 				getSprite().killAndErase();
 				destroy();
 			} else {
+				final String TXT_MESSAGE1 = Game.getVar(R.string.CagedKobold_Message1);
+				final String TXT_MESSAGE2 = Game.getVar(R.string.CagedKobold_Message2);
+				final String TXT_MESSAGE3 = Game.getVar(R.string.CagedKobold_Message3);
+
+				final String[] TXT_PHRASES = {TXT_MESSAGE1, TXT_MESSAGE2, TXT_MESSAGE3};
+
 				int index = Random.Int(0, TXT_PHRASES.length);
 				say(TXT_PHRASES[index]);
 			}
 			
 		} else {
-			GameScene.show( new WndQuest( this, TXT_QUEST_START ) );
+			GameScene.show( new WndQuest( this, Game.getVar(R.string.CagedKobold_Intro)) );
 			Quest.given = true;
 			Quest.process();
 			Journal.add( Journal.Feature.CAGEDKOBOLD.desc() );

--- a/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mobs/npc/CagedKobold.java
+++ b/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mobs/npc/CagedKobold.java
@@ -70,7 +70,7 @@ public class CagedKobold extends ImmortalNPC {
 				Item reward = new CandleOfMindVision();
 
 				if (reward.doPickUp( Dungeon.hero )) {
-					GLog.i( Hero.TXT_YOU_NOW_HAVE, reward.name() );
+					GLog.i( Hero.getHeroYouNowHave(), reward.name() );
 				} else {
 					Dungeon.level.drop(reward, hero.getPos()).sprite.drop();
 				}

--- a/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mobs/npc/HealerNPC.java
+++ b/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mobs/npc/HealerNPC.java
@@ -10,12 +10,6 @@ import com.watabou.utils.Random;
 
 public class HealerNPC extends ImmortalNPC {
 
-	private static final String TXT_MESSAGE1 = Game.getVar(R.string.HealerNPC_Message1);
-	private static final String TXT_MESSAGE2 = Game.getVar(R.string.HealerNPC_Message2);
-	private static final String TXT_MESSAGE3 = Game.getVar(R.string.HealerNPC_Message3);
-
-	private static String[] TXT_PHRASES = {TXT_MESSAGE1, TXT_MESSAGE2, TXT_MESSAGE3};
-
 	public HealerNPC() {
 		movable = false;
 	}
@@ -33,6 +27,10 @@ public class HealerNPC extends ImmortalNPC {
 		Hero hero = Dungeon.hero;
 		if (Dungeon.level.distanceL2(hero.getPos(), getPos()) < 4) {
 			if(Random.Int(20) == 0) {
+				final String[] TXT_PHRASES = {Game.getVar(R.string.HealerNPC_Message1),
+						Game.getVar(R.string.HealerNPC_Message2),
+						Game.getVar(R.string.HealerNPC_Message3)
+				};
 				say(Random.element(TXT_PHRASES));
 			}
 		}

--- a/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mobs/npc/LibrarianNPC.java
+++ b/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mobs/npc/LibrarianNPC.java
@@ -8,8 +8,6 @@ import com.watabou.pixeldungeon.windows.WndQuest;
 
 public class LibrarianNPC extends ImmortalNPC {
 
-	private static final String TXT_MESSAGE = Game.getVar(R.string.LibrarianNPC_Message_Instruction);
-
 	public LibrarianNPC() {
 	}
 
@@ -17,7 +15,7 @@ public class LibrarianNPC extends ImmortalNPC {
 	public boolean interact(final Hero hero) {
 		getSprite().turnTo( getPos(), hero.getPos() );
 
-		GameScene.show(new WndQuest(this, TXT_MESSAGE));
+		GameScene.show(new WndQuest(this, Game.getVar(R.string.LibrarianNPC_Message_Instruction)));
 		return true;
 	}
 

--- a/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mobs/npc/NecromancerNPC.java
+++ b/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mobs/npc/NecromancerNPC.java
@@ -16,14 +16,6 @@ import com.watabou.utils.Random;
 
 public class NecromancerNPC extends ImmortalNPC {
 
-	private static final String TXT_INTRO    = Game.getVar(R.string.NecromancerNPC_Intro2);
-	private static final String TXT_MESSAGE1 = Game.getVar(R.string.NecromancerNPC_Message1);
-	private static final String TXT_MESSAGE2 = Game.getVar(R.string.NecromancerNPC_Message2);
-	private static final String TXT_MESSAGE3 = Game.getVar(R.string.NecromancerNPC_Message3);
-	private static final String TXT_MESSAGE4 = Game.getVar(R.string.NecromancerNPC_Message4);
-
-	private static String[] TXT_PHRASES = {TXT_MESSAGE1, TXT_MESSAGE2, TXT_MESSAGE3, TXT_MESSAGE4};
-
 	private static final String NODE       = "necromancernpc";
 	private static final String INTRODUCED = "introduced";
 
@@ -72,7 +64,7 @@ public class NecromancerNPC extends ImmortalNPC {
 		getSprite().turnTo(getPos(), hero.getPos());
 
 		if (!introduced) {
-			GameScene.show(new WndQuest(this, TXT_INTRO));
+			GameScene.show(new WndQuest(this, Game.getVar(R.string.NecromancerNPC_Intro2)));
 			introduced = true;
 
 			SkeletonKey key = new SkeletonKey();
@@ -84,6 +76,13 @@ public class NecromancerNPC extends ImmortalNPC {
 			}
 
 		} else {
+			final String TXT_MESSAGE1 = Game.getVar(R.string.NecromancerNPC_Message1);
+			final String TXT_MESSAGE2 = Game.getVar(R.string.NecromancerNPC_Message2);
+			final String TXT_MESSAGE3 = Game.getVar(R.string.NecromancerNPC_Message3);
+			final String TXT_MESSAGE4 = Game.getVar(R.string.NecromancerNPC_Message4);
+
+			final String[] TXT_PHRASES = {TXT_MESSAGE1, TXT_MESSAGE2, TXT_MESSAGE3, TXT_MESSAGE4};
+
 			int index = Random.Int(0, TXT_PHRASES.length);
 			say(TXT_PHRASES[index]);
 		}

--- a/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mobs/npc/NecromancerNPC.java
+++ b/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mobs/npc/NecromancerNPC.java
@@ -70,7 +70,7 @@ public class NecromancerNPC extends ImmortalNPC {
 			SkeletonKey key = new SkeletonKey();
 
 			if (key.doPickUp( Dungeon.hero )) {
-				GLog.i( Hero.TXT_YOU_NOW_HAVE, key.name() );
+				GLog.i( Hero.getHeroYouNowHave(), key.name() );
 			} else {
 				Dungeon.level.drop( key, Dungeon.hero.getPos() ).sprite.drop();
 			}

--- a/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mobs/npc/PlagueDoctorNPC.java
+++ b/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mobs/npc/PlagueDoctorNPC.java
@@ -17,12 +17,6 @@ import com.watabou.utils.Random;
 
 public class PlagueDoctorNPC extends ImmortalNPC {
 
-	private static final String TXT_QUEST = Game.getVar(R.string.PlagueDoctorNPC_Quest_Reminder);
-	private static final String TXT_QUEST_END = Game.getVar(R.string.PlagueDoctorNPC_Quest_End);
-	private static final String TXT_QUEST_START_M = Game.getVar(R.string.PlagueDoctorNPC_Quest_Start_Male);
-	private static final String TXT_QUEST_START_F = Game.getVar(R.string.PlagueDoctorNPC_Quest_Start_Female);
-	private static final String TXT_QUEST_COMPLETED = Game.getVar(R.string.PlagueDoctorNPC_After_Quest);
-
 	public PlagueDoctorNPC() {
 	}
 
@@ -30,7 +24,7 @@ public class PlagueDoctorNPC extends ImmortalNPC {
 	public boolean interact(final Hero hero) {
 		getSprite().turnTo(getPos(), hero.getPos());
 		if (Quest.completed) {
-			GameScene.show(new WndQuest(this, TXT_QUEST_COMPLETED));
+			GameScene.show(new WndQuest(this, Game.getVar(R.string.PlagueDoctorNPC_After_Quest)));
 			return true;
 		}
 
@@ -49,15 +43,15 @@ public class PlagueDoctorNPC extends ImmortalNPC {
 					Dungeon.level.drop(reward, hero.getPos()).sprite.drop();
 				}
 				Quest.complete();
-				GameScene.show(new WndQuest(this, TXT_QUEST_END));
+				GameScene.show(new WndQuest(this, Game.getVar(R.string.PlagueDoctorNPC_Quest_End)));
 			} else {
-				GameScene.show(new WndQuest(this, (Utils.format(TXT_QUEST, 5)) ) );
+				GameScene.show(new WndQuest(this, (Utils.format(Game.getVar(R.string.PlagueDoctorNPC_Quest_Reminder), 5)) ) );
 			}
 
 		} else {
-			String txtQuestStart = Utils.format(TXT_QUEST_START_M, 5);
+			String txtQuestStart = Utils.format(Game.getVar(R.string.PlagueDoctorNPC_Quest_Start_Male), 5);
 			if (Dungeon.hero.getGender() == Utils.FEMININE) {
-				txtQuestStart = Utils.format(TXT_QUEST_START_F, 5);
+				txtQuestStart = Utils.format(Game.getVar(R.string.PlagueDoctorNPC_Quest_Start_Female), 5);
 			}
 			GameScene.show(new WndQuest(this, txtQuestStart));
 			Quest.process(hero.getPos());

--- a/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mobs/npc/PlagueDoctorNPC.java
+++ b/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mobs/npc/PlagueDoctorNPC.java
@@ -38,7 +38,7 @@ public class PlagueDoctorNPC extends ImmortalNPC {
 				reward.identify();
 
 				if (reward.doPickUp(Dungeon.hero)) {
-					GLog.i(Hero.TXT_YOU_NOW_HAVE, reward.name());
+					GLog.i(Hero.getHeroYouNowHave(), reward.name());
 				} else {
 					Dungeon.level.drop(reward, hero.getPos()).sprite.drop();
 				}

--- a/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mobs/npc/ScarecrowNPC.java
+++ b/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mobs/npc/ScarecrowNPC.java
@@ -70,7 +70,7 @@ public class ScarecrowNPC extends ImmortalNPC {
 				reward.quantity(5);
 
 				if (reward.doPickUp(Dungeon.hero)) {
-					GLog.i(Hero.TXT_YOU_NOW_HAVE, reward.name());
+					GLog.i(Hero.getHeroYouNowHave(), reward.name());
 				} else {
 					Dungeon.level.drop(reward, hero.getPos()).sprite.drop();
 				}

--- a/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mobs/npc/ScarecrowNPC.java
+++ b/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mobs/npc/ScarecrowNPC.java
@@ -19,11 +19,6 @@ import com.watabou.utils.Bundle;
 
 public class ScarecrowNPC extends ImmortalNPC {
 
-	private static final String TXT_QUEST_START_M = Game.getVar(R.string.ScarecrowNPC_Quest_Start_Male);
-	private static final String TXT_QUEST_START_F = Game.getVar(R.string.ScarecrowNPC_Quest_Start_Female);
-	private static final String TXT_QUEST_END     = Game.getVar(R.string.ScarecrowNPC_Quest_End);
-	private static final String TXT_QUEST         = Game.getVar(R.string.ScarecrowNPC_Quest_Reminder);
-
 	public ScarecrowNPC() {
 	}
 
@@ -80,15 +75,15 @@ public class ScarecrowNPC extends ImmortalNPC {
 					Dungeon.level.drop(reward, hero.getPos()).sprite.drop();
 				}
 				Quest.complete();
-				GameScene.show(new WndQuest(this, TXT_QUEST_END));
+				GameScene.show(new WndQuest(this, Game.getVar(R.string.ScarecrowNPC_Quest_End)));
 			} else {
-				GameScene.show(new WndQuest(this, TXT_QUEST));
+				GameScene.show(new WndQuest(this, Game.getVar(R.string.ScarecrowNPC_Quest_Reminder)));
 			}
 
 		} else {
-			String txtQuestStart = TXT_QUEST_START_M;
+			String txtQuestStart = Game.getVar(R.string.ScarecrowNPC_Quest_Start_Male);
 			if (Dungeon.hero.getGender() == Utils.FEMININE) {
-				txtQuestStart = TXT_QUEST_START_F;
+				txtQuestStart = Game.getVar(R.string.ScarecrowNPC_Quest_Start_Female);
 			}
 			GameScene.show(new WndQuest(this, txtQuestStart));
 			Quest.given = true;

--- a/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mobs/npc/TownGuardNPC.java
+++ b/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mobs/npc/TownGuardNPC.java
@@ -9,12 +9,6 @@ import com.watabou.utils.Random;
 
 public class TownGuardNPC extends ImmortalNPC {
 
-	private static final String TXT_MESSAGE1 = Game.getVar(R.string.TownGuardNPC_Message1);
-	private static final String TXT_MESSAGE2 = Game.getVar(R.string.TownGuardNPC_Message2);
-	private static final String TXT_MESSAGE3 = Game.getVar(R.string.TownGuardNPC_Message3);
-
-	private static String[] TXT_PHRASES = {TXT_MESSAGE1, TXT_MESSAGE2, TXT_MESSAGE3};
-
 	public TownGuardNPC() {
 		movable = false;
 	}
@@ -22,6 +16,12 @@ public class TownGuardNPC extends ImmortalNPC {
 	@Override
 	public boolean interact(final Hero hero) {
 		getSprite().turnTo( getPos(), hero.getPos() );
+
+		final String TXT_MESSAGE1 = Game.getVar(R.string.TownGuardNPC_Message1);
+		final String TXT_MESSAGE2 = Game.getVar(R.string.TownGuardNPC_Message2);
+		final String TXT_MESSAGE3 = Game.getVar(R.string.TownGuardNPC_Message3);
+
+		final String[] TXT_PHRASES = {TXT_MESSAGE1, TXT_MESSAGE2, TXT_MESSAGE3};
 
 		int index = Random.Int(0, TXT_PHRASES.length);
 		GameScene.show(new WndQuest(this, TXT_PHRASES[index]));

--- a/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mobs/npc/TownsfolkMovieNPC.java
+++ b/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mobs/npc/TownsfolkMovieNPC.java
@@ -8,15 +8,13 @@ import com.watabou.pixeldungeon.windows.WndQuest;
 
 public class TownsfolkMovieNPC extends ImmortalNPC {
 
-	private static final String TXT_MESSAGE = Game.getVar(R.string.TownsfolkMovieNPC_Message);
-
 	public TownsfolkMovieNPC() {
 	}
 
 	@Override
 	public boolean interact(final Hero hero) {
 		getSprite().turnTo( getPos(), hero.getPos() );
-		GameScene.show(new WndQuest(this, TXT_MESSAGE));
+		GameScene.show(new WndQuest(this, Game.getVar(R.string.TownsfolkMovieNPC_Message)));
 		return true;
 	}
 }

--- a/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mobs/npc/TownsfolkNPC.java
+++ b/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mobs/npc/TownsfolkNPC.java
@@ -9,19 +9,20 @@ import com.watabou.utils.Random;
 
 public class TownsfolkNPC extends ImmortalNPC {
 
-	private static final String TXT_MESSAGE1 = Game.getVar(R.string.TownsfolkNPC_Message1);
-	private static final String TXT_MESSAGE2 = Game.getVar(R.string.TownsfolkNPC_Message2);
-	private static final String TXT_MESSAGE3 = Game.getVar(R.string.TownsfolkNPC_Message3);
-	private static final String TXT_MESSAGE4 = Game.getVar(R.string.TownsfolkNPC_Message4);
-
-	private static String[] TXT_PHRASES = {TXT_MESSAGE1, TXT_MESSAGE2, TXT_MESSAGE3, TXT_MESSAGE4};
-
 	public TownsfolkNPC() {
 	}
 
 	@Override
 	public boolean interact(final Hero hero) {
 		getSprite().turnTo( getPos(), hero.getPos() );
+
+		final String TXT_MESSAGE1 = Game.getVar(R.string.TownsfolkNPC_Message1);
+		final String TXT_MESSAGE2 = Game.getVar(R.string.TownsfolkNPC_Message2);
+		final String TXT_MESSAGE3 = Game.getVar(R.string.TownsfolkNPC_Message3);
+		final String TXT_MESSAGE4 = Game.getVar(R.string.TownsfolkNPC_Message4);
+
+		final String[] TXT_PHRASES = {TXT_MESSAGE1, TXT_MESSAGE2, TXT_MESSAGE3, TXT_MESSAGE4};
+
 
 		int index = Random.Int(0, TXT_PHRASES.length);
 		GameScene.show(new WndQuest(this, TXT_PHRASES[index]));

--- a/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mobs/npc/TownsfolkSilentNPC.java
+++ b/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mobs/npc/TownsfolkSilentNPC.java
@@ -9,18 +9,18 @@ import com.watabou.utils.Random;
 
 public class TownsfolkSilentNPC extends ImmortalNPC {
 
-	private static final String TXT_MESSAGE1 = Game.getVar(R.string.TownsfolkSilentNPC_Message1);
-	private static final String TXT_MESSAGE2 = Game.getVar(R.string.TownsfolkSilentNPC_Message2);
-	private static final String TXT_MESSAGE3 = Game.getVar(R.string.TownsfolkSilentNPC_Message3);
-
-	private static String[] TXT_PHRASES = {TXT_MESSAGE1, TXT_MESSAGE2, TXT_MESSAGE3};
-
 	public TownsfolkSilentNPC() {
 	}
 
 	@Override
 	public boolean interact(final Hero hero) {
 		getSprite().turnTo( getPos(), hero.getPos() );
+
+		final String TXT_MESSAGE1 = Game.getVar(R.string.TownsfolkSilentNPC_Message1);
+		final String TXT_MESSAGE2 = Game.getVar(R.string.TownsfolkSilentNPC_Message2);
+		final String TXT_MESSAGE3 = Game.getVar(R.string.TownsfolkSilentNPC_Message3);
+
+		final String[] TXT_PHRASES = {TXT_MESSAGE1, TXT_MESSAGE2, TXT_MESSAGE3};
 
 		int index = Random.Int(0, TXT_PHRASES.length);
 		GameScene.show(new WndQuest(this, TXT_PHRASES[index]));

--- a/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/windows/WndFortuneTeller.java
+++ b/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/windows/WndFortuneTeller.java
@@ -24,13 +24,6 @@ import com.watabou.pixeldungeon.windows.WndQuest;
 
 public class WndFortuneTeller extends Window {
 
-	private static final String BTN_IDENTIFY     = Game.getVar(R.string.Wnd_Button_Yes);
-	private static final String BTN_NO          = Game.getVar(R.string.Wnd_Button_No);
-	private static final String TXT_INSTRUCTION = Game.getVar(R.string.WndFortuneTeller_Instruction);
-	private static final String TXT_TITLE       = Game.getVar(R.string.WndFortuneTeller_Title);
-	private static final String TXT_NO_ITEM     = Game.getVar(R.string.WndFortuneTeller_No_Item);
-
-
 	private static final int BTN_HEIGHT	= 18;
 	private static final int WIDTH		= 120;
 	private int GOLD_COST  = 50;
@@ -48,18 +41,18 @@ public class WndFortuneTeller extends Window {
 
 		IconTitle titlebar = new IconTitle();
 		titlebar.icon( new ItemSprite(new Gold()) );
-		titlebar.label( Utils.capitalize( TXT_TITLE ) );
+		titlebar.label( Utils.capitalize( Game.getVar(R.string.WndFortuneTeller_Title)) );
 		titlebar.setRect( 0, 0, WIDTH, 0 );
 		add( titlebar );
 
-		Text message = PixelScene.createMultiline( Utils.format(TXT_INSTRUCTION, GOLD_COST), GuiProperties.regularFontSize() );
+		Text message = PixelScene.createMultiline( Utils.format(Game.getVar(R.string.WndFortuneTeller_Instruction), GOLD_COST), GuiProperties.regularFontSize() );
 		message.maxWidth(WIDTH);
 		message.y = titlebar.bottom() + GAP;
 		add( message );
 
 		final FortuneTellerNPC npc = fortune;
 
-		RedButton btnYes = new RedButton( BTN_IDENTIFY + " ( "+ GOLD_COST + " )" ) {
+		RedButton btnYes = new RedButton( Game.getVar(R.string.Wnd_Button_Yes) + " ( "+ GOLD_COST + " )" ) {
 			@Override
 			protected void onClick() {
 				boolean hasTarget = false;
@@ -77,7 +70,7 @@ public class WndFortuneTeller extends Window {
 					Dungeon.gold(Dungeon.gold() - GOLD_COST);
 				} else{
 					hide();
-					GameScene.show(new WndQuest(npc, TXT_NO_ITEM));
+					GameScene.show(new WndQuest(npc, Game.getVar(R.string.WndFortuneTeller_No_Item)));
 				}
 			}
 		};
@@ -86,7 +79,7 @@ public class WndFortuneTeller extends Window {
 		add( btnYes );
 		btnYes.enable(!(Dungeon.gold()< GOLD_COST));
 
-		RedButton btnNo = new RedButton( BTN_NO ) {
+		RedButton btnNo = new RedButton( Game.getVar(R.string.Wnd_Button_No) ) {
 			@Override
 			protected void onClick() {
 				hide();

--- a/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/windows/WndMovieTheatre.java
+++ b/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/windows/WndMovieTheatre.java
@@ -23,15 +23,6 @@ import com.watabou.pixeldungeon.windows.WndMessage;
 
 public class WndMovieTheatre extends Window implements InterstitialPoint{
 
-	private static final String BTN_WATCH       = Game.getVar(R.string.WndMovieTheatre_Watch);
-	private static final String BTN_NO          = Game.getVar(R.string.WndMovieTheatre_No);
-	private static final String TXT_BYE         = Game.getVar(R.string.WndMovieTheatre_Bye);
-	private static final String TXT_INSTRUCTION = Game.getVar(R.string.WndMovieTheatre_Instruction);
-	private static final String TXT_TITLE       = Game.getVar(R.string.WndMovieTheatre_Title);
-	private static final String TXT_THANK_YOU   = Game.getVar(R.string.WndMovieTheatre_Thank_You);
-	private static final String TXT_SORRY       = Game.getVar(R.string.WndMovieTheatre_Sorry);
-	private static final String TXT_OK       = Game.getVar(R.string.WndMovieTheatre_Ok);
-
 	private static final int BTN_HEIGHT	= 18;
 	private static final int WIDTH		= 120;
 
@@ -45,11 +36,11 @@ public class WndMovieTheatre extends Window implements InterstitialPoint{
 		
 		IconTitle titlebar = new IconTitle();
 		titlebar.icon( new ItemSprite(new Gold()) );
-		titlebar.label( Utils.capitalize( TXT_TITLE ) );
+		titlebar.label( Utils.capitalize( Game.getVar(R.string.WndMovieTheatre_Title) ) );
 		titlebar.setRect( 0, 0, WIDTH, 0 );
 		add( titlebar );
 		
-		String instruction = Utils.format(TXT_INSTRUCTION, goldReward) + "\n\n" + Utils.format(Game.getVar(R.string.WndMovieTheatre_Instruction_2), filmsSeen, limit);
+		String instruction = Utils.format(Game.getVar(R.string.WndMovieTheatre_Instruction), goldReward) + "\n\n" + Utils.format(Game.getVar(R.string.WndMovieTheatre_Instruction_2), filmsSeen, limit);
 
 		Text message = PixelScene.createMultiline( instruction, GuiProperties.regularFontSize() );
 
@@ -57,7 +48,7 @@ public class WndMovieTheatre extends Window implements InterstitialPoint{
 		message.y = titlebar.bottom() + GAP;
 		add( message );
 		
-		RedButton btnYes = new RedButton( BTN_WATCH ) {
+		RedButton btnYes = new RedButton( Game.getVar(R.string.WndMovieTheatre_Watch) ) {
 			@Override
 			protected void onClick() {
 				showAd( );
@@ -66,10 +57,10 @@ public class WndMovieTheatre extends Window implements InterstitialPoint{
 		btnYes.setRect( 0, message.y + message.height() + GAP, WIDTH, BTN_HEIGHT );
 		add( btnYes );
 
-		RedButton btnNo = new RedButton( BTN_NO ) {
+		RedButton btnNo = new RedButton( Game.getVar(R.string.WndMovieTheatre_No) ) {
 			@Override
 			protected void onClick() {
-				serviceMan.say( TXT_BYE );
+				serviceMan.say( Game.getVar(R.string.WndMovieTheatre_Bye) );
 				hide();
 			}
 		};
@@ -96,15 +87,15 @@ public class WndMovieTheatre extends Window implements InterstitialPoint{
 				Dungeon.hero.doOnNextAction = new Runnable() {
 					@Override
 					public void run() {
-						GameScene.show(new WndMessage(TXT_THANK_YOU) {
+						GameScene.show(new WndMessage(Game.getVar(R.string.WndMovieTheatre_Thank_You) ) {
 							@Override
 							public void hide() {
 								super.hide();
 								if(result) {
-									serviceMan.say(TXT_OK);
+									serviceMan.say(Game.getVar(R.string.WndMovieTheatre_Ok));
 									serviceMan.reward();
 								} else {
-									serviceMan.say(TXT_SORRY);
+									serviceMan.say(Game.getVar(R.string.WndMovieTheatre_Sorry));
 								}
 
 								if (PixelDungeon.donated() == 0) {

--- a/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/windows/WndPortalWarning.java
+++ b/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/windows/WndPortalWarning.java
@@ -16,16 +16,11 @@ public class WndPortalWarning extends Window {
 	private static final int WIDTH		= 100;
 	private static final int GAP		= 2;
 
-	private static final String TXT_TITLE = Game.getVar(R.string.WndPortal_Warning_Title);
-	private static final String TXT_INFO = Game.getVar(R.string.WndPortal_Warning_Info);
-	private static final String BTN_YES = Game.getVar(R.string.Wnd_Button_Yes);
-	private static final String BTN_NO = Game.getVar(R.string.Wnd_Button_No);
-
 	public WndPortalWarning() {
 		super();
 
 		//Title text
-		Text tfTitle = PixelScene.createMultiline(TXT_TITLE, GuiProperties.mediumTitleFontSize());
+		Text tfTitle = PixelScene.createMultiline(Game.getVar(R.string.WndPortal_Warning_Title), GuiProperties.mediumTitleFontSize());
 		tfTitle.hardlight(TITLE_COLOR);
 		tfTitle.maxWidth(WIDTH - GAP);
 		tfTitle.x = (WIDTH - tfTitle.width())/2;
@@ -33,7 +28,7 @@ public class WndPortalWarning extends Window {
 		add(tfTitle);
 
 		//Instruction text
-		Text message = PixelScene.createMultiline(TXT_INFO, GuiProperties.regularFontSize() );
+		Text message = PixelScene.createMultiline(Game.getVar(R.string.WndPortal_Warning_Info), GuiProperties.regularFontSize() );
 		message.maxWidth(WIDTH);
 		message.y = tfTitle.bottom()+ GAP;
 		add( message );
@@ -42,7 +37,7 @@ public class WndPortalWarning extends Window {
 
 
 		//Yes Button
-		TextButton btnYes = new RedButton(BTN_YES) {
+		TextButton btnYes = new RedButton(Game.getVar(R.string.Wnd_Button_Yes)) {
 			@Override
 			protected void onClick() {
 				super.onClick();
@@ -56,7 +51,7 @@ public class WndPortalWarning extends Window {
 		buttonY = (int) btnYes.bottom()+ GAP;
 
 		//No Button
-		TextButton btnNo = new RedButton(BTN_NO) {
+		TextButton btnNo = new RedButton(Game.getVar(R.string.Wnd_Button_No)) {
 			@Override
 			protected void onClick() {
 				super.onClick();

--- a/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/windows/WndSadGhostNecro.java
+++ b/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/windows/WndSadGhostNecro.java
@@ -15,11 +15,6 @@ import com.watabou.pixeldungeon.windows.IconTitle;
 
 public class WndSadGhostNecro extends Window {
 
-	private static final String TXT_TEXT = Game.getVar(R.string.WndSadGhostNecro_Text);
-	private static final String TXT_YES = Game.getVar(R.string.WndSadGhostNecro_Yes);
-	private static final String TXT_NO = Game.getVar(R.string.WndSadGhostNecro_No);
-	private static final String TXT_PERSUADED = Game.getVar(R.string.WndSadGhostNecro_Persuaded);
-	
 	private static final int WIDTH		= 120;
 	private static final int BTN_HEIGHT	= 18;
 
@@ -35,15 +30,15 @@ public class WndSadGhostNecro extends Window {
 		titlebar.setRect( 0, 0, WIDTH, 0 );
 		add( titlebar );
 		
-		Text message = PixelScene.createMultiline( TXT_TEXT, GuiProperties.regularFontSize() );
+		Text message = PixelScene.createMultiline( Game.getVar(R.string.WndSadGhostNecro_Text), GuiProperties.regularFontSize() );
 		message.maxWidth(WIDTH);
 		message.y = titlebar.bottom() + GAP;
 		add( message );
 		
-		RedButton btnWeapon = new RedButton( TXT_YES ) {
+		RedButton btnWeapon = new RedButton( Game.getVar(R.string.WndSadGhostNecro_Yes) ) {
 			@Override
 			protected void onClick() {
-				GLog.w( TXT_PERSUADED );
+				GLog.w( Game.getVar(R.string.WndSadGhostNecro_Persuaded) );
 				persuade = true;
 				hide();
 			}
@@ -51,7 +46,7 @@ public class WndSadGhostNecro extends Window {
 		btnWeapon.setRect( 0, message.y + message.height() + GAP, WIDTH, BTN_HEIGHT );
 		add( btnWeapon );
 		
-		RedButton btnArmor = new RedButton( TXT_NO ) {
+		RedButton btnArmor = new RedButton( Game.getVar(R.string.WndSadGhostNecro_No) ) {
 			@Override
 			protected void onClick() {
 				persuade = false;

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/actors/Char.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/actors/Char.java
@@ -77,16 +77,6 @@ import java.util.Set;
 
 public abstract class Char extends Actor implements Presser{
 
-	private static final String TXT_HIT[]    = Game.getVars(R.array.Char_Hit);
-	private static final String TXT_KILL[]   = Game.getVars(R.array.Char_Kill);
-	private static final String TXT_DEFEAT[] = Game.getVars(R.array.Char_Defeat);
-
-	private static final String TXT_YOU_MISSED = Game.getVar(R.string.Char_YouMissed);
-	private static final String TXT_SMB_MISSED = Game.getVar(R.string.Char_SmbMissed);
-
-	private static final String   TXT_OUT_OF_PARALYSIS = Game.getVar(R.string.Char_OutParalysis);
-
-
     private int      pos      = 0;
 	public  Fraction fraction = Fraction.DUNGEON;
 
@@ -219,6 +209,7 @@ public abstract class Char extends Actor implements Presser{
 		if (hit(this, enemy, false)) {
 
 			if (visibleFight) {
+				final String TXT_HIT[]    = Game.getVars(R.array.Char_Hit);
 				GLog.i(TXT_HIT[gender], name, enemy.getName_objective());
 			}
 
@@ -248,6 +239,7 @@ public abstract class Char extends Actor implements Presser{
 			if (!enemy.isAlive() && visibleFight) {
 				if (enemy == Dungeon.hero) {
 
+					final String TXT_KILL[]   = Game.getVars(R.array.Char_Kill);
 					if (Dungeon.hero.killerGlyph != null) {
 
 						Dungeon.fail(Utils.format(ResultDescriptions.GLYPH, Dungeon.hero.killerGlyph.name(), Dungeon.depth));
@@ -265,6 +257,7 @@ public abstract class Char extends Actor implements Presser{
 					}
 
 				} else {
+					final String TXT_DEFEAT[] = Game.getVars(R.array.Char_Defeat);
 					GLog.i(TXT_DEFEAT[gender], name, enemy.getName_objective());
 				}
 			}
@@ -277,9 +270,9 @@ public abstract class Char extends Actor implements Presser{
 				String defense = enemy.defenseVerb();
 				enemy.getSprite().showStatus(CharSprite.NEUTRAL, defense);
 				if (this == Dungeon.hero) {
-					GLog.i(TXT_YOU_MISSED, enemy.name, defense);
+					GLog.i(Game.getVar(R.string.Char_YouMissed), enemy.name, defense);
 				} else {
-					GLog.i(TXT_SMB_MISSED, enemy.name, defense, name);
+					GLog.i(Game.getVar(R.string.Char_SmbMissed), enemy.name, defense, name);
 				}
 
 				Sample.INSTANCE.play(Assets.SND_MISS);
@@ -364,7 +357,7 @@ public abstract class Char extends Actor implements Presser{
 			if (Random.Int(dmg) >= Random.Int(hp())) {
 				Buff.detach(this, Paralysis.class);
 				if (Dungeon.visible[getPos()]) {
-					GLog.i(TXT_OUT_OF_PARALYSIS, getName_objective());
+					GLog.i(Game.getVar(R.string.Char_OutParalysis), getName_objective());
 				}
 			}
 		}

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/actors/blobs/WaterOfAwareness.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/actors/blobs/WaterOfAwareness.java
@@ -40,8 +40,6 @@ import com.watabou.pixeldungeon.utils.GLog;
 
 public class WaterOfAwareness extends WellWater {
 
-	private static final String TXT_PROCCED = Game.getVar(R.string.WaterOfAwareness_Procced);
-	
 	@Override
 	protected boolean affectHero( Hero hero ) {
 		
@@ -69,8 +67,8 @@ public class WaterOfAwareness extends WellWater {
 
 		Dungeon.hero.interrupt();
 	
-		GLog.p( TXT_PROCCED );
-		
+		GLog.p( Game.getVar(R.string.WaterOfAwareness_Procced) );
+
 		Journal.remove( Feature.WELL_OF_AWARENESS.desc() );
 		
 		return true;

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/actors/blobs/WaterOfHealth.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/actors/blobs/WaterOfHealth.java
@@ -37,8 +37,6 @@ import com.watabou.pixeldungeon.utils.GLog;
 
 public class WaterOfHealth extends WellWater {
 
-	private static final String TXT_PROCCED = Game.getVar(R.string.WaterOfHealth_Procced);
-	
 	@Override
 	protected boolean affectHero( Hero hero ) {
 		
@@ -52,7 +50,7 @@ public class WaterOfHealth extends WellWater {
 
 		Dungeon.hero.interrupt();
 	
-		GLog.p( TXT_PROCCED );
+		GLog.p( Game.getVar(R.string.WaterOfHealth_Procced) );
 		
 		Journal.remove( Feature.WELL_OF_HEALTH.desc() );
 		

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/actors/buffs/Burning.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/actors/buffs/Burning.java
@@ -40,9 +40,6 @@ import com.watabou.utils.Random;
 
 public class Burning extends Buff implements Hero.Doom {
 
-	private static final String TXT_BURNS_UP		= Game.getVar(R.string.Burning_Burns);
-	private static final String TXT_BURNED_TO_DEATH	= Game.getVar(R.string.Burning_Death);
-	
 	private static final float DURATION = 8f;
 	
 	private float left;
@@ -71,7 +68,7 @@ public class Burning extends Buff implements Hero.Doom {
 		}
 		@Override
 		public String actionText(Item srcItem) {
-			return Utils.format(TXT_BURNS_UP, srcItem.toString());
+			return Utils.format(Game.getVar(R.string.Burning_Burns), srcItem.toString());
 		}
 	}
 		
@@ -133,6 +130,6 @@ public class Burning extends Buff implements Hero.Doom {
 		Badges.validateDeathFromFire();
 		
 		Dungeon.fail( Utils.format( ResultDescriptions.BURNING, Dungeon.depth ) );
-		GLog.n( TXT_BURNED_TO_DEATH );
+		GLog.n( Game.getVar(R.string.Burning_Death) );
 	}
 }

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/actors/buffs/Frost.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/actors/buffs/Frost.java
@@ -27,8 +27,6 @@ import com.watabou.pixeldungeon.ui.BuffIndicator;
 import com.watabou.pixeldungeon.utils.Utils;
 
 public class Frost extends FlavourBuff {
-
-	private static final String TXT_SHATTERS = Game.getVar(R.string.Frost_Shatter);
 	private static final float DURATION	= 5f;
 	
 	class freezeItem implements itemAction{
@@ -40,7 +38,7 @@ public class Frost extends FlavourBuff {
 
 		public String actionText(Item srcItem) {
 			if(srcItem instanceof Potion) {
-				return Utils.format(TXT_SHATTERS, srcItem.toString());
+				return Utils.format(Game.getVar(R.string.Frost_Shatter), srcItem.toString());
 			}
 			return null;
 		}

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/actors/buffs/Hunger.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/actors/buffs/Hunger.java
@@ -113,7 +113,7 @@ public class Hunger extends Buff implements Hero.Doom {
 				float newLevel = level + delta;
 				boolean statusUpdated = false;
 				if (newLevel >= STARVING) {
-					
+					final String[] TXT_STARVING = Game.getVars(R.array.Hunger_Starving);
 					GLog.n( TXT_STARVING[hero.getGender()] );
 					statusUpdated = true;
 					

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/actors/buffs/Hunger.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/actors/buffs/Hunger.java
@@ -38,12 +38,7 @@ public class Hunger extends Buff implements Hero.Doom {
 	
 	public static final float HUNGRY	= 260f;
 	public static final float STARVING	= 360f;
-	
-	private static final String[] TXT_HUNGRY	= Game.getVars(R.array.Hunger_Hungry);
-	private static final String[] TXT_STARVING	= Game.getVars(R.array.Hunger_Starving);
-	
-	private static final String TXT_DEATH		= Game.getVar(R.string.Hunger_Death);
-	
+
 	private float level;
 
 	private static final String LEVEL	= "level";
@@ -69,7 +64,8 @@ public class Hunger extends Buff implements Hero.Doom {
 			if (isStarving()) {
 
 				if (Random.Float() < 0.3f && (target.hp() > 1 || !target.paralysed)) {
-					
+
+					final String[] TXT_STARVING	= Game.getVars(R.array.Hunger_Starving);
 					GLog.n( TXT_STARVING[hero.getGender()] );
 					
 					if(hero.getDifficulty() >= 3) {
@@ -124,7 +120,7 @@ public class Hunger extends Buff implements Hero.Doom {
 					hero.interrupt();
 					
 				} else if (newLevel >= HUNGRY && level < HUNGRY) {
-					
+					final String[] TXT_HUNGRY = Game.getVars(R.array.Hunger_Hungry);
 					GLog.w( TXT_HUNGRY[hero.getGender()] );
 					statusUpdated = true;
 					
@@ -195,6 +191,6 @@ public class Hunger extends Buff implements Hero.Doom {
 		Badges.validateDeathFromHunger();
 		
 		Dungeon.fail( Utils.format( ResultDescriptions.HUNGER, Dungeon.depth ) );
-		GLog.n( TXT_DEATH );
+		GLog.n( Game.getVar(R.string.Hunger_Death) );
 	}
 }

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/actors/buffs/Ooze.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/actors/buffs/Ooze.java
@@ -26,8 +26,6 @@ import com.watabou.pixeldungeon.utils.GLog;
 import com.watabou.pixeldungeon.utils.Utils;
 
 public class Ooze extends Buff {
-	
-	private static final String TXT_DEATH = Game.getVar(R.string.Ooze_Death);
 
 	public int damage	= 1;
 	
@@ -47,7 +45,7 @@ public class Ooze extends Buff {
 			target.damage( damage, this );
 			if (!target.isAlive() && target == Dungeon.hero) {
 				Dungeon.fail( Utils.format( ResultDescriptions.OOZE, Dungeon.depth ) );
-				GLog.n( TXT_DEATH, toString() );
+				GLog.n( Game.getVar(R.string.Ooze_Death), toString() );
 			}
 			spend( TICK );
 		}

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/actors/hero/Hero.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/actors/hero/Hero.java
@@ -139,22 +139,7 @@ import java.util.Collection;
 import java.util.Set;
 
 public class Hero extends Char implements PetOwner {
-
 	private static final String TXT_EXP   = "%+dEXP";
-	private static final String TXT_LEAVE = Game.getVar(R.string.Hero_Leave);
-
-	private static final String TXT_LEVEL_UP  = Game.getVar(R.string.Hero_LevelUp);
-	private static final String TXT_NEW_LEVEL = Game.getVar(R.string.Hero_NewLevel);
-
-	public static final String TXT_YOU_NOW_HAVE = Game.getVar(R.string.Hero_YouNowHave);
-
-	private static final String TXT_SOMETHING_ELSE = Game.getVar(R.string.Hero_SomethingElse);
-	private static final String TXT_LOCKED_CHEST   = Game.getVar(R.string.Hero_LockedChest);
-	private static final String TXT_LOCKED_DOOR    = Game.getVar(R.string.Hero_LockedDoor);
-	private static final String TXT_NOTICED_SMTH   = Game.getVar(R.string.Hero_NoticedSmth);
-
-	private static final String TXT_WAIT   = Game.getVar(R.string.Hero_Wait);
-	private static final String TXT_SEARCH = Game.getVar(R.string.Hero_Search);
 
 	public static final int STARTING_STR = 10;
 
@@ -748,7 +733,7 @@ public class Hero extends Char implements PetOwner {
 						itemPickedUp(item);
 
 						if (!heap.isEmpty()) {
-							GLog.i(TXT_SOMETHING_ELSE);
+							GLog.i(Game.getVar(R.string.Hero_SomethingElse));
 						}
 						curAction = null;
 					} else {
@@ -781,9 +766,9 @@ public class Hero extends Char implements PetOwner {
 	public void itemPickedUp(Item item) {
 		if ((item instanceof ScrollOfUpgrade && ((ScrollOfUpgrade) item).isKnown())
 				|| (item instanceof PotionOfStrength && ((PotionOfStrength) item).isKnown())) {
-			GLog.p(TXT_YOU_NOW_HAVE, item.name());
+			GLog.p(Game.getVar(R.string.Hero_YouNowHave), item.name());
 		} else {
-			GLog.i(TXT_YOU_NOW_HAVE, item.name());
+			GLog.i(getHeroYouNowHave(), item.name());
 		}
 	}
 
@@ -802,7 +787,7 @@ public class Hero extends Char implements PetOwner {
 					theKey = belongings.getKey(GoldenKey.class, Dungeon.depth, Dungeon.level.levelId);
 
 					if (theKey == null) {
-						GLog.w(TXT_LOCKED_CHEST);
+						GLog.w(Game.getVar(R.string.Hero_LockedChest));
 						ready();
 						return false;
 					}
@@ -856,7 +841,7 @@ public class Hero extends Char implements PetOwner {
 				getSprite().operate(doorCell);
 				Sample.INSTANCE.play(Assets.SND_UNLOCK);
 			} else {
-				GLog.w(TXT_LOCKED_DOOR);
+				GLog.w(Game.getVar(R.string.Hero_LockedDoor));
 				ready();
 			}
 
@@ -912,7 +897,7 @@ public class Hero extends Char implements PetOwner {
 			if (nextLevel.levelId.equals("0")) {
 
 				if (belongings.getItem(Amulet.class) == null) {
-					GameScene.show(new WndMessage(TXT_LEAVE));
+					GameScene.show(new WndMessage(Game.getVar(R.string.Hero_Leave)));
 					ready();
 				} else {
 					Dungeon.win(ResultDescriptions.WIN, Rankings.gameOver.WIN_HAPPY);
@@ -1015,7 +1000,7 @@ public class Hero extends Char implements PetOwner {
 	public void rest(boolean tillHealthy) {
 		spendAndNext(TIME_TO_REST);
 		if (!tillHealthy) {
-			getSprite().showStatus(CharSprite.DEFAULT, TXT_WAIT);
+			getSprite().showStatus(CharSprite.DEFAULT, Game.getVar(R.string.Hero_Wait));
 		}
 		restoreHealth = tillHealthy;
 	}
@@ -1379,8 +1364,8 @@ public class Hero extends Char implements PetOwner {
 
 		if (levelUp) {
 
-			GLog.p(TXT_NEW_LEVEL, lvl());
-			getSprite().showStatus(CharSprite.POSITIVE, TXT_LEVEL_UP);
+			GLog.p(Game.getVar(R.string.Hero_NewLevel), lvl());
+			getSprite().showStatus(CharSprite.POSITIVE, Game.getVar(R.string.Hero_LevelUp));
 			Sample.INSTANCE.play(Assets.SND_LEVELUP);
 
 			if (this.getSoulPointsMax() > 0) {
@@ -1715,7 +1700,7 @@ public class Hero extends Char implements PetOwner {
 		}
 
 		if (intentional) {
-			getSprite().showStatus(CharSprite.DEFAULT, TXT_SEARCH);
+			getSprite().showStatus(CharSprite.DEFAULT, Game.getVar(R.string.Hero_Search));
 			getSprite().operate(getPos());
 			if (smthFound) {
 				spendAndNext(Random.Float() < searchLevel ? TIME_TO_SEARCH : TIME_TO_SEARCH * 2);
@@ -1726,7 +1711,7 @@ public class Hero extends Char implements PetOwner {
 		}
 
 		if (smthFound) {
-			GLog.w(TXT_NOTICED_SMTH);
+			GLog.w(Game.getVar(R.string.Hero_NoticedSmth));
 			Sample.INSTANCE.play(Assets.SND_SECRET);
 			interrupt();
 		}
@@ -1787,6 +1772,10 @@ public class Hero extends Char implements PetOwner {
 
 	private void lvl(int lvl) {
 		this.lvl = Scrambler.scramble(lvl);
+	}
+
+	public static final String getHeroYouNowHave() {
+		return Game.getVar(R.string.Hero_YouNowHave);
 	}
 
 	public int getExp() {

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/actors/mobs/Brute.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/actors/mobs/Brute.java
@@ -31,8 +31,6 @@ import com.watabou.utils.Random;
 
 public class Brute extends Mob {
 
-	private static final String TXT_ENRAGED = Game.getVar(R.string.Brute_Enraged);
-	
 	public Brute() {
 		spriteClass = BruteSprite.class;
 		
@@ -81,7 +79,7 @@ public class Brute extends Mob {
 			enraged = true;
 			spend( TICK );
 			if (Dungeon.visible[getPos()]) {
-				GLog.w( TXT_ENRAGED, getName() );
+				GLog.w( Game.getVar(R.string.Brute_Enraged), getName() );
 				getSprite().showStatus( CharSprite.NEGATIVE, Game.getVar(R.string.Brute_StaEnraged));
 			}
 		}

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/actors/mobs/Eye.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/actors/mobs/Eye.java
@@ -41,28 +41,26 @@ import com.watabou.pixeldungeon.utils.Utils;
 import com.watabou.utils.Random;
 
 public class Eye extends Mob {
-	
-	private static final String TXT_DEATHGAZE_KILLED = Game.getVar(R.string.Eye_Kill);
-	
+
 	public Eye() {
 		spriteClass = EyeSprite.class;
-		
+
 		hp(ht(100));
 		defenseSkill = 20;
 
-		
+
 		exp = 13;
 		maxLvl = 25;
-		
+
 		flying = true;
-		
+
 		loot = new Dewdrop();
 		lootChance = 0.5f;
-		
+
 		RESISTANCES.add( WandOfDisintegration.class );
 		RESISTANCES.add( Death.class );
 		RESISTANCES.add( Leech.class );
-		
+
 		IMMUNITIES.add( Terror.class );
 	}
 
@@ -146,7 +144,7 @@ public class Eye extends Mob {
 				
 				if (!ch.isAlive() && ch == Dungeon.hero) {
 					Dungeon.fail( Utils.format( ResultDescriptions.MOB, Utils.indefinite( getName() ), Dungeon.depth ) );
-					GLog.n( TXT_DEATHGAZE_KILLED, getName() );
+					GLog.n( Game.getVar(R.string.Eye_Kill), getName() );
 				}
 			} else {
 				ch.getSprite().showStatus( CharSprite.NEUTRAL,  ch.defenseVerb() );

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/actors/mobs/Mob.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/actors/mobs/Mob.java
@@ -79,8 +79,6 @@ import java.util.Map;
 
 public abstract class Mob extends Char {
 
-	private static final String TXT_DIED = Game.getVar(R.string.Mob_Died);
-
 	protected static final String TXT_RAGE = "#$%^";
 
 	private static final float SPLIT_DELAY = 1f;
@@ -616,7 +614,7 @@ public abstract class Mob extends Char {
 		}
 
 		if (hero.isAlive() && !Dungeon.visible[getPos()]) {
-			GLog.i(TXT_DIED);
+			GLog.i(Game.getVar(R.string.Mob_Died));
 		}
 	}
 

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/actors/mobs/npcs/Blacksmith.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/actors/mobs/npcs/Blacksmith.java
@@ -46,15 +46,6 @@ import java.util.Collection;
 
 public class Blacksmith extends NPC {
 
-	private static final String TXT_GOLD_1       = Game.getVar(R.string.Blacksmith_Gold1);
-	private static final String TXT_BLOOD_1      = Game.getVar(R.string.Blacksmith_Blood1);
-	private static final String TXT2             = Game.getVar(R.string.Blacksmith_Txt2);
-	private static final String TXT3             = Game.getVar(R.string.Blacksmith_Txt3);
-	private static final String TXT4             = Game.getVar(R.string.Blacksmith_Txt4);
-	private static final String TXT_COMPLETED    = Game.getVar(R.string.Blacksmith_Completed);
-	private static final String TXT_GET_LOST     = Game.getVar(R.string.Blacksmith_GetLost);
-	private static final String TXT_LOOKS_BETTER = Game.getVar(R.string.Blacksmith_LooksBetter);
-	
 	{
 		spriteClass = BlacksmithSprite.class;
 	}
@@ -73,7 +64,10 @@ public class Blacksmith extends NPC {
 		if (!Quest.given) {
 			
 			GameScene.show( new WndQuest( this, 
-				Quest.alternative ? TXT_BLOOD_1 : TXT_GOLD_1 ) {
+				Quest.alternative ?
+						Game.getVar(R.string.Blacksmith_Blood1) :
+						Game.getVar(R.string.Blacksmith_Gold1) )
+			{
 				
 				@Override
 				public void onBackPressed() {
@@ -84,7 +78,7 @@ public class Blacksmith extends NPC {
 					
 					Pickaxe pick = new Pickaxe();
 					if (pick.doPickUp( hero )) {
-						GLog.i( Hero.TXT_YOU_NOW_HAVE, pick.name() );
+						GLog.i( Hero.getHeroYouNowHave(), pick.name() );
 					} else {
 						Dungeon.level.drop( pick, hero.getPos() ).sprite.drop();
 					}
@@ -98,15 +92,15 @@ public class Blacksmith extends NPC {
 				
 				Pickaxe pick = hero.belongings.getItem( Pickaxe.class );
 				if (pick == null) {
-					tell( TXT2 );
+					tell( Game.getVar(R.string.Blacksmith_Txt2) );
 				} else if (!pick.bloodStained) {
-					tell( TXT4 );
+					tell( Game.getVar(R.string.Blacksmith_Txt4) );
 				} else {
 					if (pick.isEquipped( hero )) {
 						pick.doUnequip( hero, false );
 					}
 					pick.detach( hero.belongings.backpack );
-					tell( TXT_COMPLETED );
+					tell( Game.getVar(R.string.Blacksmith_Completed) );
 					
 					Quest.completed = true;
 					Quest.reforged = false;
@@ -117,16 +111,16 @@ public class Blacksmith extends NPC {
 				Pickaxe pick = hero.belongings.getItem( Pickaxe.class );
 				DarkGold gold = hero.belongings.getItem( DarkGold.class );
 				if (pick == null) {
-					tell( TXT2 );
+					tell( Game.getVar(R.string.Blacksmith_Txt2) );
 				} else if (gold == null || gold.quantity() < 15) {
-					tell( TXT3 );
+					tell( Game.getVar(R.string.Blacksmith_Txt3) );
 				} else {
 					if (pick.isEquipped( hero )) {
 						pick.doUnequip( hero, false );
 					}
 					pick.detach( hero.belongings.backpack );
 					gold.detachAll( hero.belongings.backpack );
-					tell( TXT_COMPLETED );
+					tell( Game.getVar(R.string.Blacksmith_Completed) );
 					
 					Quest.completed = true;
 					Quest.reforged = false;
@@ -139,7 +133,7 @@ public class Blacksmith extends NPC {
 			
 		} else {
 			
-			tell( TXT_GET_LOST );
+			tell( Game.getVar(R.string.Blacksmith_GetLost) );
 			
 		}
 		return true;
@@ -197,7 +191,7 @@ public class Blacksmith extends NPC {
 			((EquipableItem)first).doUnequip( Dungeon.hero, true );
 		}
 		first.upgrade();
-		GLog.p( TXT_LOOKS_BETTER, first.name() );
+		GLog.p( Game.getVar(R.string.Blacksmith_LooksBetter), first.name() );
 		Dungeon.hero.spendAndNext( 2f );
 		Badges.validateItemLevelAcquired( first );
 		

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/actors/mobs/npcs/Ghost.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/actors/mobs/npcs/Ghost.java
@@ -66,11 +66,6 @@ public class Ghost extends NPC {
 		
 		setState(WANDERING);
 	}
-	
-	private static final String TXT_ROSE1 = Game.getVar(R.string.Ghost_Rose1);
-	private static final String TXT_ROSE2 = Game.getVar(R.string.Ghost_Rose2);
-	private static final String TXT_RAT1  = Game.getVar(R.string.Ghost_Rat1);
-	private static final String TXT_RAT2  = Game.getVar(R.string.Ghost_Rat2);
 
 	private static final String INTRODUCED = "introduced";
 	private static final String PERSUADE = "persuade";
@@ -148,7 +143,7 @@ public class Ghost extends NPC {
 			if (persuade || item != null) {
 				GameScene.show( new WndSadGhost( this, item ) );
 			} else {
-				GameScene.show( new WndQuest( this, Quest.alternative ? TXT_RAT2 : TXT_ROSE2 ) );
+				GameScene.show( new WndQuest( this, Quest.alternative ? Game.getVar(R.string.Ghost_Rat2): Game.getVar(R.string.Ghost_Rose2) ) );
 				
 				int newPos = -1;
 				for (int i=0; i < 10; i++) {
@@ -169,7 +164,7 @@ public class Ghost extends NPC {
 			}
 			
 		} else {
-			GameScene.show( new WndQuest( this, Quest.alternative ? TXT_RAT1 : TXT_ROSE1 ) );
+			GameScene.show( new WndQuest( this, Quest.alternative ? Game.getVar(R.string.Ghost_Rat1): Game.getVar(R.string.Ghost_Rose1) ) );
 			Quest.given = true;
 			
 			Journal.add( Journal.Feature.GHOST.desc() );

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/actors/mobs/npcs/Imp.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/actors/mobs/npcs/Imp.java
@@ -46,14 +46,7 @@ public class Imp extends NPC {
 	public Imp() {
 		spriteClass = ImpSprite.class;
 	}
-	
-	private static final String TXT_GOLEMS1	= Game.getVar(R.string.Imp_Golems1);
-	private static final String TXT_GOLEMS2	= Game.getVar(R.string.Imp_Golems2);
-	private static final String TXT_MONKS1	= Game.getVar(R.string.Imp_Monks1);
-	private static final String TXT_MONKS2	= Game.getVar(R.string.Imp_Monks2);	
-	private static final String TXT_CYA	    = Game.getVar(R.string.Imp_Cya);
-	private static final String TXT_HEY	    = Game.getVar(R.string.Imp_Hey);
-	
+
 	private boolean seenBefore = false;
 	
 	@Override
@@ -61,7 +54,7 @@ public class Imp extends NPC {
 		
 		if (!Quest.given && Dungeon.visible[getPos()]) {
 			if (!seenBefore) {
-				say( Utils.format( TXT_HEY, Dungeon.hero.className() ) );
+				say( Utils.format( Game.getVar(R.string.Imp_Hey), Dungeon.hero.className() ) );
 			}
 			seenBefore = true;
 		} else {
@@ -106,11 +99,11 @@ public class Imp extends NPC {
 			if (tokens != null && (tokens.quantity() >= 8 || (!Quest.alternative && tokens.quantity() >= 6))) {
 				GameScene.show( new WndImp( this, tokens ) );
 			} else {
-				tell( Quest.alternative ? TXT_MONKS2 : TXT_GOLEMS2, hero.className() );
+				tell( Quest.alternative ? Game.getVar(R.string.Imp_Monks2) : Game.getVar(R.string.Imp_Golems2), hero.className() );
 			}
 			
 		} else {
-			tell( Quest.alternative ? TXT_MONKS1 : TXT_GOLEMS1 );
+			tell( Quest.alternative ? Game.getVar(R.string.Imp_Monks1) : Game.getVar(R.string.Imp_Golems1) );
 			Quest.given = true;
 			Quest.completed = false;
 			
@@ -127,7 +120,7 @@ public class Imp extends NPC {
 	
 	public void flee() {
 		
-		say( Utils.format( TXT_CYA, Dungeon.hero.className() ) );
+		say( Utils.format( Game.getVar(R.string.Imp_Cya), Dungeon.hero.className() ) );
 		
 		destroy();
 		getSprite().die();

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/actors/mobs/npcs/ImpShopkeeper.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/actors/mobs/npcs/ImpShopkeeper.java
@@ -29,8 +29,6 @@ import com.watabou.pixeldungeon.utils.Utils;
 
 public class ImpShopkeeper extends Shopkeeper {
 
-	private static final String TXT_GREETINGS = Game.getVar(R.string.ImpShopkeeper_Greetings);
-	
 	{
 		spriteClass = ImpSprite.class;
 	}
@@ -41,7 +39,7 @@ public class ImpShopkeeper extends Shopkeeper {
 	protected boolean act() {
 
 		if (!seenBefore && Dungeon.visible[getPos()]) {
-			say( Utils.format( TXT_GREETINGS ) );
+			say( Utils.format( Game.getVar(R.string.ImpShopkeeper_Greetings) ) );
 			seenBefore = true;
 		}
 		

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/actors/mobs/npcs/WandMaker.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/actors/mobs/npcs/WandMaker.java
@@ -69,12 +69,7 @@ public class WandMaker extends NPC {
 	{	
 		spriteClass = WandmakerSprite.class;
 	}
-	
-	private static final String TXT_BERRY1 = Game.getVar(R.string.WandMaker_Berry1);
-	private static final String TXT_BERRY2 = Game.getVar(R.string.WandMaker_Berry2);
-	private static final String TXT_DUST1  = Game.getVar(R.string.WandMaker_Dust1);
-	private static final String TXT_DUST2  = Game.getVar(R.string.WandMaker_Dust2);
-	
+
 	@Override
 	protected boolean act() {
 		throwItem();
@@ -111,11 +106,11 @@ public class WandMaker extends NPC {
 			if (item != null) {
 				GameScene.show( new WndWandmaker( this, item ) );
 			} else {
-				tell( Quest.alternative ? TXT_DUST2 : TXT_BERRY2, hero.className() );
+				tell( Quest.alternative ? Game.getVar(R.string.WandMaker_Dust2) : Game.getVar(R.string.WandMaker_Berry2), hero.className() );
 			}
 			
 		} else {
-			tell( Quest.alternative ? TXT_DUST1 : TXT_BERRY1 );
+			tell( Quest.alternative ? Game.getVar(R.string.WandMaker_Dust1) : Game.getVar(R.string.WandMaker_Berry1) );
 			Quest.given = true;
 			
 			Quest.placeItem();
@@ -290,12 +285,9 @@ public class WandMaker extends NPC {
 	
 	public static class Rotberry extends Plant {
 		
-		private static final String TXT_NAME = Game.getVar(R.string.WandMaker_RotberryName);
-		private static final String TXT_DESC = Game.getVar(R.string.WandMaker_RotberryDesc);
-		
 		{
 			image = 7;
-			plantName = TXT_NAME;
+			plantName = Game.getVar(R.string.WandMaker_RotberryName);
 		}
 		
 		@Override
@@ -313,12 +305,12 @@ public class WandMaker extends NPC {
 		
 		@Override
 		public String desc() {
-			return TXT_DESC;
+			return Game.getVar(R.string.WandMaker_RotberryDesc);
 		}
 		
 		public static class Seed extends Plant.Seed {
 			{
-				plantName = TXT_NAME;
+				plantName = Game.getVar(R.string.WandMaker_RotberryName);
 				
 				name = Utils.format(TXT_SEED, plantName);
 				image = ItemSpriteSheet.SEED_ROTBERRY;
@@ -353,7 +345,7 @@ public class WandMaker extends NPC {
 			
 			@Override
 			public String desc() {
-				return TXT_DESC;
+				return Game.getVar(R.string.WandMaker_RotberryDesc);
 			}
 		}
 	}

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/Stylus.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/Stylus.java
@@ -113,7 +113,7 @@ public class Stylus extends Item {
 		
 		Scroll inscribedScroll = Scroll.createRandomScroll();
 		getCurUser().collect(inscribedScroll);
-		GLog.i(Hero.TXT_YOU_NOW_HAVE, inscribedScroll.name());	// Let know which scroll was inscribed
+		GLog.i(Hero.getHeroYouNowHave(), inscribedScroll.name());	// Let know which scroll was inscribed
 	}
 	
 	@Override

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/quest/Pickaxe.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/quest/Pickaxe.java
@@ -104,7 +104,7 @@ public class Pickaxe extends Weapon {
 							
 							DarkGold gold = new DarkGold();
 							if (gold.doPickUp( Dungeon.hero )) {
-								GLog.i( Hero.TXT_YOU_NOW_HAVE, gold.name() );
+								GLog.i( Hero.getHeroYouNowHave(), gold.name() );
 							} else {
 								Dungeon.level.drop( gold, hero.getPos() ).sprite.drop();
 							}

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/wands/WandOfFlock.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/wands/WandOfFlock.java
@@ -106,8 +106,6 @@ public class WandOfFlock extends SimpleWand  {
 			spriteClass = SheepSprite.class;
 		}
 
-		private static final String[] QUOTES = Game.getVars(R.array.WandOfFlock_SheepBaa);
-		
 		public float lifespan;
 		
 		private boolean initialized = false;
@@ -133,6 +131,7 @@ public class WandOfFlock extends SimpleWand  {
 
 		@Override
 		public boolean interact(final Hero hero) {
+			final String[] QUOTES = Game.getVars(R.array.WandOfFlock_SheepBaa);
 			say( Random.element( QUOTES ) );
 			return false;
 		}

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/windows/WndImp.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/windows/WndImp.java
@@ -76,7 +76,7 @@ public class WndImp extends Window {
 
 		reward.identify();
 		if (reward.doPickUp( Dungeon.hero )) {
-			GLog.i( Hero.TXT_YOU_NOW_HAVE, reward.name() );
+			GLog.i( Hero.getHeroYouNowHave(), reward.name() );
 		} else {
 			Dungeon.level.drop( reward, imp.getPos() ).sprite.drop();
 		}

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/windows/WndSadGhost.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/windows/WndSadGhost.java
@@ -86,7 +86,7 @@ public class WndSadGhost extends Window {
 		item.removeItemFrom(Dungeon.hero);
 
 		if (reward.doPickUp( Dungeon.hero )) {
-			GLog.i( Hero.TXT_YOU_NOW_HAVE, reward.name() );
+			GLog.i( Hero.getHeroYouNowHave(), reward.name() );
 		} else {
 			Dungeon.level.drop( reward, ghost.getPos() ).sprite.drop();
 		}

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/windows/WndWandmaker.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/windows/WndWandmaker.java
@@ -87,7 +87,7 @@ public class WndWandmaker extends Window {
 
 		reward.identify();
 		if (reward.doPickUp( Dungeon.hero )) {
-			GLog.i( Hero.TXT_YOU_NOW_HAVE, reward.name() );
+			GLog.i( Hero.getHeroYouNowHave(), reward.name() );
 		} else {
 			Dungeon.level.drop( reward, wandmaker.getPos() ).sprite.drop();
 		}


### PR DESCRIPTION
This PR fixes some of the `private static final String TXT_...` issues and moves the resolution of the string to the time when it's needed. Some cases ([like these lines](https://github.com/NYRDS/pixel-dungeon-remix/compare/master...swooboo:swooboo-static-fields?expand=1#diff-059776023d7a6ab345f5a5296cfb3f75R84)) feature arrays of strings and their random choice. I copied all the fields as is and removed the fields qualifiers. In the above example:

This:
```java
	private static final String TXT_MESSAGE1 = Game.getVar(R.string.CagedKobold_Message1);
	private static final String TXT_MESSAGE2 = Game.getVar(R.string.CagedKobold_Message2);
	private static final String TXT_MESSAGE3 = Game.getVar(R.string.CagedKobold_Message3);

	private static String[] TXT_PHRASES = {TXT_MESSAGE1, TXT_MESSAGE2, TXT_MESSAGE3};
```

Will become this (in a later place in code where it's actually needed):
```java
	final String TXT_MESSAGE1 = Game.getVar(R.string.CagedKobold_Message1);
	final String TXT_MESSAGE2 = Game.getVar(R.string.CagedKobold_Message2);
	final String TXT_MESSAGE3 = Game.getVar(R.string.CagedKobold_Message3);

	final String[] TXT_PHRASES = {TXT_MESSAGE1, TXT_MESSAGE2, TXT_MESSAGE3};
```

This is done for clarity and minimality of each commit. Also these are the most complicated cases.