### PR TITLE
Fix even more static string fields, part of #37

### DIFF
--- a/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/levels/objects/PortalGate.java
+++ b/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/levels/objects/PortalGate.java
@@ -28,9 +28,6 @@ public abstract class PortalGate extends LevelObject {
 	@Packable
 	protected int uses;
 
-	protected static final String TXT_USED = Game.getVar(R.string.PortalGate_Used);
-	protected static final String TXT_ACTIVATED = Game.getVar(R.string.PortalGate_Activated);
-
 	public PortalGate(){
 		this(-1);
 	}
@@ -119,7 +116,7 @@ public abstract class PortalGate extends LevelObject {
 				playActiveLoop();
 				activated = true;
 				animationRunning = false;
-				GLog.w( TXT_ACTIVATED );
+				GLog.w( Game.getVar(R.string.PortalGate_Activated) );
 			}
 		}, image() + 0, image() + 1, image() + 2, image() + 3, image() + 4, image() + 5, image() + 6, image() + 7, image() + 8, image() + 9, image() + 10, image() + 11, image() + 12, image() + 13, image() + 14, image() + 15, image() + 16);
 

--- a/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/levels/objects/PortalGateReceiver.java
+++ b/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/levels/objects/PortalGateReceiver.java
@@ -1,6 +1,8 @@
 package com.nyrds.pixeldungeon.levels.objects;
 
+import com.nyrds.pixeldungeon.ml.R;
 import com.nyrds.pixeldungeon.windows.WndPortalReturn;
+import com.watabou.noosa.Game;
 import com.watabou.pixeldungeon.actors.hero.Hero;
 import com.watabou.pixeldungeon.items.Amulet;
 import com.watabou.pixeldungeon.scenes.GameScene;
@@ -19,7 +21,7 @@ public class PortalGateReceiver extends PortalGate {
 				}
 			}
 		} else{
-			GLog.w( TXT_USED );
+			GLog.w( Game.getVar(R.string.PortalGate_Used) );
 		}
 		return false;
 	}

--- a/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/levels/objects/PortalGateSender.java
+++ b/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/levels/objects/PortalGateSender.java
@@ -1,7 +1,9 @@
 package com.nyrds.pixeldungeon.levels.objects;
 
+import com.nyrds.pixeldungeon.ml.R;
 import com.nyrds.pixeldungeon.utils.Position;
 import com.nyrds.pixeldungeon.windows.WndPortal;
+import com.watabou.noosa.Game;
 import com.watabou.pixeldungeon.actors.hero.Hero;
 import com.watabou.pixeldungeon.items.Amulet;
 import com.watabou.pixeldungeon.levels.Level;
@@ -28,7 +30,7 @@ public class PortalGateSender extends PortalGate {
 				}
 			}
 		} else{
-			GLog.w( TXT_USED );
+			GLog.w( Game.getVar(R.string.PortalGate_Used) );
 		}
 		return false;
 	}

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/actors/mobs/npcs/WandMaker.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/actors/mobs/npcs/WandMaker.java
@@ -312,7 +312,7 @@ public class WandMaker extends NPC {
 			{
 				plantName = Game.getVar(R.string.WandMaker_RotberryName);
 				
-				name = Utils.format(TXT_SEED, plantName);
+				name = Utils.format(Game.getVar(R.string.Plant_Seed), plantName);
 				image = ItemSpriteSheet.SEED_ROTBERRY;
 				
 				plantClass = Rotberry.class;

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/Item.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/Item.java
@@ -61,7 +61,6 @@ import java.util.Comparator;
 
 public class Item implements Bundlable, Presser {
 
-	private static final   String TXT_PACK_FULL = Game.getVar(R.string.Item_PackFull);
 	protected static final String TXT_DIR_THROW = Game.getVar(R.string.Item_DirThrow);
 
 	private static final String TXT_TO_STRING       = "%s";
@@ -205,7 +204,7 @@ public class Item implements Bundlable, Presser {
 
 		} else {
 
-			GLog.n(TXT_PACK_FULL, name());
+			GLog.n(Game.getVar(R.string.Item_PackFull), name());
 			return false;
 
 		}

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/Item.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/Item.java
@@ -61,8 +61,6 @@ import java.util.Comparator;
 
 public class Item implements Bundlable, Presser {
 
-	protected static final String TXT_DIR_THROW = Game.getVar(R.string.Item_DirThrow);
-
 	private static final String TXT_TO_STRING       = "%s";
 	private static final String TXT_TO_STRING_X     = "%s x%d";
 	private static final String TXT_TO_STRING_LVL   = "%s%+d";
@@ -499,7 +497,7 @@ public class Item implements Bundlable, Presser {
 
 		@Override
 		public String prompt() {
-			return TXT_DIR_THROW;
+			return Game.getVar(R.string.Item_DirThrow);
 		}
 	};
 

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/Weightstone.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/Weightstone.java
@@ -39,10 +39,6 @@ import java.util.ArrayList;
 
 public class Weightstone extends Item {
 	
-	private static final String TXT_SELECT_WEAPON = Game.getVar(R.string.Weightstone_Select);
-	private static final String TXT_FAST          = Game.getVar(R.string.Weightstone_Fast);
-	private static final String TXT_ACCURATE      = Game.getVar(R.string.Weightstone_Accurate);
-	
 	private static final float TIME_TO_APPLY = 2;
 	
 	private static final String AC_APPLY = "Weightstone_ACApply";
@@ -66,7 +62,7 @@ public class Weightstone extends Item {
 		if (action == AC_APPLY) {
 
 			setCurUser(hero);
-			GameScene.selectItem( itemSelector, WndBag.Mode.WEAPON, TXT_SELECT_WEAPON );
+			GameScene.selectItem( itemSelector, WndBag.Mode.WEAPON, Game.getVar(R.string.Weightstone_Select) );
 			
 		} else {
 			
@@ -91,10 +87,10 @@ public class Weightstone extends Item {
 		
 		if (forSpeed) {
 			weapon.imbue = Weapon.Imbue.SPEED;
-			GLog.p( TXT_FAST, weapon.name() );
+			GLog.p( Game.getVar(R.string.Weightstone_Fast), weapon.name() );
 		} else {
 			weapon.imbue = Weapon.Imbue.ACCURACY;
-			GLog.p( TXT_ACCURATE, weapon.name() );
+			GLog.p( Game.getVar(R.string.Weightstone_Accurate), weapon.name() );
 		}
 		
 		getCurUser().getSprite().operate( getCurUser().getPos() );

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/armor/BattleMageArmor.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/armor/BattleMageArmor.java
@@ -18,7 +18,7 @@ public class BattleMageArmor extends MageArmor {
         if (hero.subClass == HeroSubClass.BATTLEMAGE) {
             return super.doEquip(hero);
         } else {
-            GLog.w(TXT_NOT_MAGE);
+            GLog.w(Game.getVar(R.string.MageArmor_NotMage));
             return false;
         }
     }

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/armor/BerserkArmor.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/armor/BerserkArmor.java
@@ -20,7 +20,7 @@ public class BerserkArmor extends WarriorArmor {
 		if (hero.subClass == HeroSubClass.BERSERKER) {
 			return super.doEquip( hero );
 		} else {
-			GLog.w( TXT_NOT_WARRIOR );
+			GLog.w( Game.getVar(R.string.WarriorArmor_NotWarrior) );
 			return false;
 		}
 	}

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/armor/ElfArmor.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/armor/ElfArmor.java
@@ -16,8 +16,6 @@ import com.watabou.pixeldungeon.utils.GLog;
 
 public class ElfArmor extends ClassArmor {
 	
-	protected static final String TXT_NOT_ELF = Game.getVar(R.string.ElfArmor_NotElf);
-
 	public ElfArmor() {
 		image = 17;
 		hasHelmet = true;
@@ -51,7 +49,7 @@ public class ElfArmor extends ClassArmor {
 		if (hero.heroClass == HeroClass.ELF) {
 			return super.doEquip( hero );
 		} else {
-			GLog.w( TXT_NOT_ELF );
+			GLog.w( Game.getVar(R.string.ElfArmor_NotElf) );
 			return false;
 		}
 	}

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/armor/GladiatorArmor.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/armor/GladiatorArmor.java
@@ -19,7 +19,7 @@ public class GladiatorArmor extends WarriorArmor {
 		if (hero.subClass == HeroSubClass.GLADIATOR) {
 			return super.doEquip( hero );
 		} else {
-			GLog.w( TXT_NOT_WARRIOR );
+			GLog.w( Game.getVar(R.string.WarriorArmor_NotWarrior) );
 			return false;
 		}
 	}

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/armor/MageArmor.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/armor/MageArmor.java
@@ -34,8 +34,6 @@ import com.watabou.pixeldungeon.utils.GLog;
 
 public class MageArmor extends ClassArmor {
 
-	protected static final String TXT_NOT_MAGE = Game.getVar(R.string.MageArmor_NotMage);
-	
 	{
 		image = 11;
 	}
@@ -73,7 +71,7 @@ public class MageArmor extends ClassArmor {
 		if (hero.heroClass == HeroClass.MAGE) {
 			return super.doEquip( hero );
 		} else {
-			GLog.w( TXT_NOT_MAGE );
+			GLog.w( Game.getVar(R.string.MageArmor_NotMage) );
 			return false;
 		}
 	}

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/armor/ScoutArmor.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/armor/ScoutArmor.java
@@ -20,7 +20,7 @@ public class ScoutArmor extends ElfArmor {
 		if (hero.subClass == HeroSubClass.SCOUT) {
 			return super.doEquip( hero );
 		} else {
-			GLog.w( TXT_NOT_ELF );
+			GLog.w( Game.getVar(R.string.ElfArmor_NotElf) );
 			return false;
 		}
 	}

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/armor/ShamanArmor.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/armor/ShamanArmor.java
@@ -20,7 +20,7 @@ public class ShamanArmor extends ElfArmor {
 		if (hero.subClass == HeroSubClass.SHAMAN) {
 			return super.doEquip( hero );
 		} else {
-			GLog.w( TXT_NOT_ELF );
+			GLog.w( Game.getVar(R.string.ElfArmor_NotElf) );
 			return false;
 		}
 	}

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/armor/WarlockArmor.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/armor/WarlockArmor.java
@@ -19,7 +19,7 @@ public class WarlockArmor extends MageArmor {
 		if (hero.subClass == HeroSubClass.WARLOCK) {
 			return super.doEquip( hero );
 		} else {
-			GLog.w( TXT_NOT_MAGE );
+			GLog.w( Game.getVar(R.string.MageArmor_NotMage) );
 			return false;
 		}
 	}

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/armor/WarriorArmor.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/armor/WarriorArmor.java
@@ -43,8 +43,6 @@ public class WarriorArmor extends ClassArmor {
 	private static int LEAP_TIME	= 1;
 	private static int SHOCK_TIME	= 3;
 
-	protected static final String TXT_NOT_WARRIOR	= Game.getVar(R.string.WarriorArmor_NotWarrior);
-	
 	{
 		image = 5;
 	}
@@ -64,7 +62,7 @@ public class WarriorArmor extends ClassArmor {
 		if (hero.heroClass == HeroClass.WARRIOR) {
 			return super.doEquip( hero );
 		} else {
-			GLog.w( TXT_NOT_WARRIOR );
+			GLog.w( Game.getVar(R.string.WarriorArmor_NotWarrior) );
 			return false;
 		}
 	}

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/weapon/melee/Kusarigama.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/weapon/melee/Kusarigama.java
@@ -1,5 +1,7 @@
 package com.watabou.pixeldungeon.items.weapon.melee;
 
+import com.nyrds.pixeldungeon.ml.R;
+import com.watabou.noosa.Game;
 import com.watabou.pixeldungeon.Dungeon;
 import com.watabou.pixeldungeon.DungeonTilemap;
 import com.watabou.pixeldungeon.actors.Actor;
@@ -60,7 +62,7 @@ public class Kusarigama extends SpecialWeapon {
 
 		@Override
 		public String prompt() {
-			return TXT_DIR_THROW;
+			return Game.getVar(R.string.Item_DirThrow);
 		}
 	};
 

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/levels/features/AlchemyPot.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/levels/features/AlchemyPot.java
@@ -25,8 +25,6 @@ import com.watabou.pixeldungeon.scenes.GameScene;
 import com.watabou.pixeldungeon.windows.WndBag;
 
 public class AlchemyPot {
-
-	private static final String TXT_SELECT_SEED	= Game.getVar(R.string.AlchemyPot_SelectSeed); 
 	
 	private static Hero hero;
 	private static int pos;
@@ -36,7 +34,7 @@ public class AlchemyPot {
 		AlchemyPot.hero = hero;
 		AlchemyPot.pos = pos;
 		
-		GameScene.selectItem( itemSelector, WndBag.Mode.SEED, TXT_SELECT_SEED );
+		GameScene.selectItem( itemSelector, WndBag.Mode.SEED, Game.getVar(R.string.AlchemyPot_SelectSeed) );
 	}
 	
 	private static final WndBag.Listener itemSelector = new WndBag.Listener() {

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/levels/features/Chasm.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/levels/features/Chasm.java
@@ -41,17 +41,15 @@ import com.watabou.pixeldungeon.windows.WndOptions;
 import com.watabou.utils.Random;
 
 public class Chasm {
-	
-	private static final String TXT_CHASM = Game.getVar(R.string.Chasm_Chasm);
-	private static final String TXT_YES   = Game.getVar(R.string.Chasm_Yes);
-	private static final String TXT_NO    = Game.getVar(R.string.Chasm_No);
-	private static final String TXT_JUMP  = Game.getVar(R.string.Chasm_Jump);
-	
+
 	public static boolean jumpConfirmed = false;
 	
 	public static void heroJump( final Hero hero ) {
 		GameScene.show( 
-			new WndOptions( TXT_CHASM, TXT_JUMP, TXT_YES, TXT_NO ) {
+			new WndOptions( Game.getVar(R.string.Chasm_Chasm),
+					Game.getVar(R.string.Chasm_Jump),
+					Game.getVar(R.string.Chasm_Yes),
+					Game.getVar(R.string.Chasm_No) ) {
 				@Override
 				protected void onSelect( int index ) {
 					if (index == 0) {

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/levels/traps/TrapHelper.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/levels/traps/TrapHelper.java
@@ -9,11 +9,6 @@ import com.watabou.pixeldungeon.windows.WndOptions;
 
 public class TrapHelper {
 
-	private static final String TXT_CHASM = Game.getVar(R.string.TrapWnd_Title);
-	private static final String TXT_YES   = Game.getVar(R.string.Chasm_Yes);
-	private static final String TXT_NO    = Game.getVar(R.string.Chasm_No);
-	private static final String TXT_STEP  = Game.getVar(R.string.TrapWnd_Step);
-
 	public static boolean stepConfirmed = false;
 
 	public static boolean isVisibleTrap(int cellType){
@@ -22,7 +17,7 @@ public class TrapHelper {
 
 	public static void heroTriggerTrap( final Hero hero ) {
 		GameScene.show(
-				new WndOptions( TXT_CHASM, TXT_STEP, TXT_YES, TXT_NO ) {
+				new WndOptions( Game.getVar(R.string.TrapWnd_Title), Game.getVar(R.string.TrapWnd_Step), Game.getVar(R.string.Chasm_Yes), Game.getVar(R.string.Chasm_No) ) {
 					@Override
 					protected void onSelect( int index ) {
 						if (index == 0) {

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/plants/Dreamweed.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/plants/Dreamweed.java
@@ -53,7 +53,7 @@ public class Dreamweed extends Plant {
 		{
 			plantName = Game.getVar(R.string.Dreamweed_Name);
 			
-			name = Utils.format(TXT_SEED, plantName);
+			name = Utils.format(Game.getVar(R.string.Plant_Seed), plantName);
 			image = ItemSpriteSheet.SEED_DREAMWEED;
 			
 			plantClass = Dreamweed.class;

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/plants/Dreamweed.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/plants/Dreamweed.java
@@ -35,12 +35,9 @@ import com.watabou.pixeldungeon.utils.Utils;
 
 public class Dreamweed extends Plant {
 
-	private static final String TXT_NAME = Game.getVar(R.string.Dreamweed_Name);
-	private static final String TXT_DESC = Game.getVar(R.string.Dreamweed_Desc);
-	
 	public Dreamweed() {
 		image = 3;
-		plantName = TXT_NAME;
+		plantName = Game.getVar(R.string.Dreamweed_Name);
 	}
 	
 	public void effect(int pos, Char ch) {
@@ -49,12 +46,12 @@ public class Dreamweed extends Plant {
 	
 	@Override
 	public String desc() {
-		return TXT_DESC;
+		return Game.getVar(R.string.Dreamweed_Desc);
 	}
 	
 	public static class Seed extends Plant.Seed {
 		{
-			plantName = TXT_NAME;
+			plantName = Game.getVar(R.string.Dreamweed_Name);
 			
 			name = Utils.format(TXT_SEED, plantName);
 			image = ItemSpriteSheet.SEED_DREAMWEED;
@@ -65,7 +62,7 @@ public class Dreamweed extends Plant {
 		
 		@Override
 		public String desc() {
-			return TXT_DESC;
+			return Game.getVar(R.string.Dreamweed_Desc);
 		}
 		
 		@Override

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/plants/Earthroot.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/plants/Earthroot.java
@@ -62,7 +62,7 @@ public class Earthroot extends Plant {
 		{
 			plantName = Game.getVar(R.string.Earthroot_Name);
 			
-			name = Utils.format(TXT_SEED, plantName);
+			name = Utils.format(Game.getVar(R.string.Plant_Seed), plantName);
 			image = ItemSpriteSheet.SEED_EARTHROOT;
 			
 			plantClass = Earthroot.class;

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/plants/Earthroot.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/plants/Earthroot.java
@@ -37,12 +37,9 @@ import com.watabou.utils.Bundle;
 
 public class Earthroot extends Plant {
 
-	private static final String TXT_NAME = Game.getVar(R.string.Earthroot_Name);
-	private static final String TXT_DESC = Game.getVar(R.string.Earthroot_Desc);
-	
 	public Earthroot() {
 		image = 5;
-		plantName = TXT_NAME;
+		plantName = Game.getVar(R.string.Earthroot_Name);
 	}
 
 	public void effect(int pos, Char ch) {
@@ -58,12 +55,12 @@ public class Earthroot extends Plant {
 	
 	@Override
 	public String desc() {
-		return TXT_DESC;
+		return Game.getVar(R.string.Earthroot_Desc);
 	}
 	
 	public static class Seed extends Plant.Seed {
 		{
-			plantName = TXT_NAME;
+			plantName = Game.getVar(R.string.Earthroot_Name);
 			
 			name = Utils.format(TXT_SEED, plantName);
 			image = ItemSpriteSheet.SEED_EARTHROOT;
@@ -74,7 +71,7 @@ public class Earthroot extends Plant {
 		
 		@Override
 		public String desc() {
-			return TXT_DESC;
+			return Game.getVar(R.string.Earthroot_Desc);
 		}
 		
 		@Override

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/plants/Fadeleaf.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/plants/Fadeleaf.java
@@ -71,7 +71,7 @@ public class Fadeleaf extends Plant {
 		{
 			plantName = Game.getVar(R.string.Fadeleaf_Name);
 			
-			name = Utils.format(TXT_SEED, plantName);
+			name = Utils.format(Game.getVar(R.string.Plant_Seed), plantName);
 			image = ItemSpriteSheet.SEED_FADELEAF;
 			
 			plantClass = Fadeleaf.class;

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/plants/Fadeleaf.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/plants/Fadeleaf.java
@@ -35,12 +35,9 @@ import com.watabou.pixeldungeon.utils.Utils;
 
 public class Fadeleaf extends Plant {
 
-	private static final String TXT_NAME = Game.getVar(R.string.Fadeleaf_Name);
-	private static final String TXT_DESC = Game.getVar(R.string.Fadeleaf_Desc);
-	
 	public Fadeleaf () {
 		image = 6;
-		plantName = TXT_NAME;
+		plantName = Game.getVar(R.string.Fadeleaf_Name);
 	}
 	
 	public void effect(int pos, Char ch) {
@@ -67,12 +64,12 @@ public class Fadeleaf extends Plant {
 	
 	@Override
 	public String desc() {
-		return TXT_DESC;
+		return Game.getVar(R.string.Fadeleaf_Desc);
 	}
 	
 	public static class Seed extends Plant.Seed {
 		{
-			plantName = TXT_NAME;
+			plantName = Game.getVar(R.string.Fadeleaf_Name);
 			
 			name = Utils.format(TXT_SEED, plantName);
 			image = ItemSpriteSheet.SEED_FADELEAF;
@@ -83,7 +80,7 @@ public class Fadeleaf extends Plant {
 		
 		@Override
 		public String desc() {
-			return TXT_DESC;
+			return Game.getVar(R.string.Fadeleaf_Desc);
 		}
 		
 		@Override

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/plants/Firebloom.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/plants/Firebloom.java
@@ -37,12 +37,9 @@ import com.watabou.pixeldungeon.utils.Utils;
 
 public class Firebloom extends Plant {
 
-	private static final String TXT_NAME = Game.getVar(R.string.Firebloom_Name);
-	private static final String TXT_DESC = Game.getVar(R.string.Firebloom_Desc);
-
 	public Firebloom() {
 		image = 0;
-		plantName = TXT_NAME;
+		plantName = Game.getVar(R.string.Firebloom_Name);
 	}
 
 	public void effect(int pos, Char ch) {
@@ -55,12 +52,12 @@ public class Firebloom extends Plant {
 
 	@Override
 	public String desc() {
-		return TXT_DESC;
+		return Game.getVar(R.string.Firebloom_Desc);
 	}
 
 	public static class Seed extends Plant.Seed {
 		{
-			plantName = TXT_NAME;
+			plantName = Game.getVar(R.string.Firebloom_Name);
 
 			name = Utils.format(TXT_SEED, plantName);
 			image = ItemSpriteSheet.SEED_FIREBLOOM;
@@ -71,7 +68,7 @@ public class Firebloom extends Plant {
 
 		@Override
 		public String desc() {
-			return TXT_DESC;
+			return Game.getVar(R.string.Firebloom_Desc);
 		}
 
 		@Override

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/plants/Firebloom.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/plants/Firebloom.java
@@ -59,7 +59,7 @@ public class Firebloom extends Plant {
 		{
 			plantName = Game.getVar(R.string.Firebloom_Name);
 
-			name = Utils.format(TXT_SEED, plantName);
+			name = Utils.format(Game.getVar(R.string.Plant_Seed), plantName);
 			image = ItemSpriteSheet.SEED_FIREBLOOM;
 
 			plantClass = Firebloom.class;

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/plants/Icecap.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/plants/Icecap.java
@@ -37,12 +37,9 @@ import com.watabou.utils.Random;
 
 public class Icecap extends Plant {
 
-	private static final String TXT_NAME = Game.getVar(R.string.Icecap_Name);
-	private static final String TXT_DESC = Game.getVar(R.string.Icecap_Desc);
-	
 	public Icecap() {
 		image = 1;
-		plantName = TXT_NAME;
+		plantName = Game.getVar(R.string.Icecap_Name);
 	}
 	
 	@Override
@@ -61,12 +58,12 @@ public class Icecap extends Plant {
 	
 	@Override
 	public String desc() {
-		return TXT_DESC;
+		return Game.getVar(R.string.Icecap_Desc);
 	}
 	
 	public static class Seed extends Plant.Seed {
 		{
-			plantName = TXT_NAME;
+			plantName = Game.getVar(R.string.Icecap_Name);
 			
 			name = Utils.format(TXT_SEED, plantName);
 			image = ItemSpriteSheet.SEED_ICECAP;
@@ -77,7 +74,7 @@ public class Icecap extends Plant {
 		
 		@Override
 		public String desc() {
-			return TXT_DESC;
+			return Game.getVar(R.string.Icecap_Desc);
 		}
 		
 		@Override

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/plants/Icecap.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/plants/Icecap.java
@@ -65,7 +65,7 @@ public class Icecap extends Plant {
 		{
 			plantName = Game.getVar(R.string.Icecap_Name);
 			
-			name = Utils.format(TXT_SEED, plantName);
+			name = Utils.format(Game.getVar(R.string.Plant_Seed), plantName);
 			image = ItemSpriteSheet.SEED_ICECAP;
 			
 			plantClass = Icecap.class;

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/plants/Plant.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/plants/Plant.java
@@ -109,7 +109,6 @@ public class Plant implements Bundlable {
 	public static class Seed extends Item {
 
 		public static final String AC_PLANT = "Plant_ACPlant";
-		private static final String TXT_INFO = Game.getVar(R.string.Plant_Info);
 		protected static final String TXT_SEED = Game
 				.getVar(R.string.Plant_Seed);
 
@@ -200,7 +199,7 @@ public class Plant implements Bundlable {
 
 		@Override
 		public String info() {
-			return Utils.format(TXT_INFO, Utils.indefinite(plantName), desc());
+			return Utils.format(Game.getVar(R.string.Plant_Info), Utils.indefinite(plantName), desc());
 		}
 	}
 }

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/plants/Plant.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/plants/Plant.java
@@ -109,8 +109,6 @@ public class Plant implements Bundlable {
 	public static class Seed extends Item {
 
 		public static final String AC_PLANT = "Plant_ACPlant";
-		protected static final String TXT_SEED = Game
-				.getVar(R.string.Plant_Seed);
 
 		private static final float TIME_TO_PLANT = 1f;
 

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/plants/Sorrowmoss.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/plants/Sorrowmoss.java
@@ -34,12 +34,9 @@ import com.watabou.pixeldungeon.utils.Utils;
 
 public class Sorrowmoss extends Plant {
 
-	private static final String TXT_NAME = Game.getVar(R.string.Sorrowmoss_Name);
-	private static final String TXT_DESC = Game.getVar(R.string.Sorrowmoss_Desc);
-	
 	public Sorrowmoss() {
 		image = 2;
-		plantName = TXT_NAME;
+		plantName = Game.getVar(R.string.Sorrowmoss_Name);
 	}
 	
 	public void effect(int pos, Char ch ) {
@@ -54,12 +51,12 @@ public class Sorrowmoss extends Plant {
 	
 	@Override
 	public String desc() {
-		return TXT_DESC;
+		return Game.getVar(R.string.Sorrowmoss_Desc);
 	}
 	
 	public static class Seed extends Plant.Seed {
 		{
-			plantName = TXT_NAME;
+			plantName = Game.getVar(R.string.Sorrowmoss_Name);
 			
 			name = Utils.format(TXT_SEED, plantName);
 			image = ItemSpriteSheet.SEED_SORROWMOSS;
@@ -70,7 +67,7 @@ public class Sorrowmoss extends Plant {
 		
 		@Override
 		public String desc() {
-			return TXT_DESC;
+			return Game.getVar(R.string.Sorrowmoss_Desc);
 		}
 		
 		@Override

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/plants/Sorrowmoss.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/plants/Sorrowmoss.java
@@ -58,7 +58,7 @@ public class Sorrowmoss extends Plant {
 		{
 			plantName = Game.getVar(R.string.Sorrowmoss_Name);
 			
-			name = Utils.format(TXT_SEED, plantName);
+			name = Utils.format(Game.getVar(R.string.Plant_Seed), plantName);
 			image = ItemSpriteSheet.SEED_SORROWMOSS;
 			
 			plantClass = Sorrowmoss.class;

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/plants/Sungrass.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/plants/Sungrass.java
@@ -38,12 +38,9 @@ import com.watabou.utils.Random;
 
 public class Sungrass extends Plant {
 
-	private static final String TXT_NAME = Game.getVar(R.string.Sungrass_Name);
-	private static final String TXT_DESC = Game.getVar(R.string.Sungrass_Desc);
-
 	public Sungrass() {
 		image = 4;
-		plantName = TXT_NAME;
+		plantName = Game.getVar(R.string.Sungrass_Name);
 	}
 
 	public void effect(int pos, Char ch) {
@@ -58,12 +55,12 @@ public class Sungrass extends Plant {
 
 	@Override
 	public String desc() {
-		return TXT_DESC;
+		return Game.getVar(R.string.Sungrass_Desc);
 	}
 
 	public static class Seed extends Plant.Seed {
 		{
-			plantName = TXT_NAME;
+			plantName = Game.getVar(R.string.Sungrass_Name);
 
 			name = Utils.format(TXT_SEED, plantName);
 			image = ItemSpriteSheet.SEED_SUNGRASS;
@@ -74,7 +71,7 @@ public class Sungrass extends Plant {
 
 		@Override
 		public String desc() {
-			return TXT_DESC;
+			return Game.getVar(R.string.Sungrass_Desc);
 		}
 
 		@Override

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/plants/Sungrass.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/plants/Sungrass.java
@@ -62,7 +62,7 @@ public class Sungrass extends Plant {
 		{
 			plantName = Game.getVar(R.string.Sungrass_Name);
 
-			name = Utils.format(TXT_SEED, plantName);
+			name = Utils.format(Game.getVar(R.string.Plant_Seed), plantName);
 			image = ItemSpriteSheet.SEED_SUNGRASS;
 
 			plantClass = Sungrass.class;

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/scenes/AboutScene.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/scenes/AboutScene.java
@@ -36,25 +36,18 @@ import com.watabou.pixeldungeon.ui.Window;
 
 public class AboutScene extends PixelScene {
 
-	private static final String TXT          = Game.getVar(R.string.AboutScene_Txt_Intro);
-	private static final String TXT_CODE     = Game.getVar(R.string.AboutScene_Code) + " " + Game.getVar(R.string.AboutScene_Code_Names);
-	private static final String TXT_GRAPHICS = Game.getVar(R.string.AboutScene_Graphics) + " " + Game.getVar(R.string.AboutScene_Graphics_Names);
-	private static final String TXT_MUSIC    = Game.getVar(R.string.AboutScene_Music) + " " + Game.getVar(R.string.AboutScene_Music_Names);
-	private static final String TXT_SOUND    = Game.getVar(R.string.AboutScene_Sound) + " " + Game.getVar(R.string.AboutScene_Sound_Names);
-	private static final String TXT_THANKS   = Game.getVar(R.string.AboutScene_Thanks) + " " + Game.getVar(R.string.AboutScene_Thanks_Names);
-	private static final String TXT_EMAIL_US = Game.getVar(R.string.AboutScene_Email_Us);
-
-	private static final String OUR_SITE = Game.getVar(R.string.AboutScene_OurSite);
-	private static final String LNK = Game.getVar(R.string.AboutScene_Lnk);
-	private static final String SND = Game.getVar(R.string.AboutScene_Snd);
-	private static final String TRN = Game.getVar(R.string.AboutScene_Translation) + "\n\t" + Game.getVar(R.string.AboutScene_Translation_Names);
-
 	private static String getTXT() {
-		return TXT + "\n\n" + TXT_CODE + "\n\n" + TXT_GRAPHICS + "\n\n" + TXT_MUSIC + "\n\n" + TXT_SOUND + "\n\n" + TXT_THANKS + "\n\n" + TXT_EMAIL_US;
+		return Game.getVar(R.string.AboutScene_Txt_Intro) + "\n\n"
+				+ Game.getVar(R.string.AboutScene_Code) + " " + Game.getVar(R.string.AboutScene_Code_Names) + "\n\n"
+				+ Game.getVar(R.string.AboutScene_Graphics) + " " + Game.getVar(R.string.AboutScene_Graphics_Names) + "\n\n"
+				+ Game.getVar(R.string.AboutScene_Music) + " " + Game.getVar(R.string.AboutScene_Music_Names) + "\n\n"
+				+ Game.getVar(R.string.AboutScene_Sound) + " " + Game.getVar(R.string.AboutScene_Sound_Names) + "\n\n"
+				+ Game.getVar(R.string.AboutScene_Thanks) + " " + Game.getVar(R.string.AboutScene_Thanks_Names) + "\n\n"
+				+ Game.getVar(R.string.AboutScene_Email_Us);
 	}
 
 	private static String getTRN() {
-		return TRN;
+		return Game.getVar(R.string.AboutScene_Translation) + "\n\t" + Game.getVar(R.string.AboutScene_Translation_Names);
 	}
 
 	private Text createTouchEmail(final String address, Text text2)
@@ -70,7 +63,7 @@ public class AboutScene extends PixelScene {
 				intent.putExtra(Intent.EXTRA_EMAIL, new String[]{address} );
 				intent.putExtra(Intent.EXTRA_SUBJECT, Game.getVar(R.string.app_name) );
 
-				Game.instance().startActivity( Intent.createChooser(intent, SND) );
+				Game.instance().startActivity( Intent.createChooser(intent, Game.getVar(R.string.AboutScene_Snd)) );
 			}
 		};
 		add(area);
@@ -85,7 +78,7 @@ public class AboutScene extends PixelScene {
 		TouchArea area = new TouchArea( text ) {
 			@Override
 			protected void onClick( Touch touch ) {
-				Game.instance().openUrl(OUR_SITE, address);
+				Game.instance().openUrl(Game.getVar(R.string.AboutScene_OurSite), address);
 			}
 		};
 		add(area);
@@ -124,7 +117,7 @@ public class AboutScene extends PixelScene {
 		Text email = createTouchEmail(Game.getVar(R.string.AboutScene_Mail), text);
 
 		Text visit = createText(Game.getVar(R.string.AboutScene_OurSite), email);
-		Text site  = createTouchLink(LNK, visit);		
+		Text site  = createTouchLink(Game.getVar(R.string.AboutScene_Lnk), visit);
 		
 		createText("\n"+ getTRN(), site);
 		

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/scenes/AmuletScene.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/scenes/AmuletScene.java
@@ -34,10 +34,6 @@ import com.watabou.utils.Random;
 
 public class AmuletScene extends PixelScene {
 
-	private static final String TXT_EXIT = Game.getVar(R.string.AmuletScene_Exit);
-	private static final String TXT_STAY = Game.getVar(R.string.AmuletScene_Stay);
-	private static final String TXT      = Game.getVar(R.string.AmuletScene_Txt);
-	
 	private static final int WIDTH			= 120;
 	private static final int BTN_HEIGHT		= 18;
 	private static final float SMALL_GAP	= 2;
@@ -53,7 +49,7 @@ public class AmuletScene extends PixelScene {
 		
 		Text text = null;
 		if (!noText) {
-			text = createMultiline( TXT, GuiProperties.regularFontSize() );
+			text = createMultiline( Game.getVar(R.string.AmuletScene_Txt), GuiProperties.regularFontSize() );
 			text.maxWidth(WIDTH);
 			add( text );
 		}
@@ -61,7 +57,7 @@ public class AmuletScene extends PixelScene {
 		amulet = new Image( Assets.AMULET );
 		add( amulet );
 		
-		RedButton btnExit = new RedButton( TXT_EXIT ) {
+		RedButton btnExit = new RedButton( Game.getVar(R.string.AmuletScene_Exit) ) {
 			@Override
 			protected void onClick() {
 				Dungeon.win( ResultDescriptions.WIN, Rankings.gameOver.WIN_AMULET );
@@ -72,7 +68,7 @@ public class AmuletScene extends PixelScene {
 		btnExit.setSize( WIDTH, BTN_HEIGHT );
 		add( btnExit );
 		
-		RedButton btnStay = new RedButton( TXT_STAY ) {
+		RedButton btnStay = new RedButton( Game.getVar(R.string.AmuletScene_Stay) ) {
 			@Override
 			protected void onClick() {
 				onBackPressed();

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/scenes/BadgesScene.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/scenes/BadgesScene.java
@@ -35,9 +35,7 @@ import com.watabou.pixeldungeon.ui.ScrollPane;
 import com.watabou.pixeldungeon.ui.Window;
 
 public class BadgesScene extends PixelScene {
-	
-	private static final String TXT_TITLE = Game.getVar(R.string.BadgesScene_Title);
-	
+
 	@Override
 	public void create() {
 		super.create();
@@ -63,7 +61,7 @@ public class BadgesScene extends PixelScene {
 		panel.y = (h - ph) / 2;
 		add( panel );
 		
-		Text title = PixelScene.createText( TXT_TITLE, GuiProperties.titleFontSize());
+		Text title = PixelScene.createText( Game.getVar(R.string.BadgesScene_Title), GuiProperties.titleFontSize());
 		title.hardlight( Window.TITLE_COLOR );
 		title.x = align( (w - title.width()) / 2 );
 		title.y = align( (panel.y - title.baseLine()) / 2 );

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/scenes/GameScene.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/scenes/GameScene.java
@@ -89,15 +89,6 @@ import java.util.HashSet;
 
 public class GameScene extends PixelScene {
 
-    private static final String TXT_WELCOME      = Game.getVar(R.string.GameScene_Welcome);
-    private static final String TXT_WELCOME_BACK = Game.getVar(R.string.GameScene_WelcomeBack);
-    private static final String TXT_NIGHT_MODE   = Game.getVar(R.string.GameScene_NightMode);
-
-    private static final String TXT_CHASM   = Game.getVar(R.string.GameScene_Chasm);
-    private static final String TXT_WATER   = Game.getVar(R.string.GameScene_Water);
-    private static final String TXT_GRASS   = Game.getVar(R.string.GameScene_Grass);
-    private static final String TXT_SECRETS = Game.getVar(R.string.GameScene_Secrets);
-
     private static final float MAX_BRIGHTNESS = 1.22f;
 
     private static volatile GameScene scene;
@@ -329,30 +320,30 @@ public class GameScene extends PixelScene {
         add(log);
 
         if (Dungeon.depth < Statistics.deepestFloor) {
-            GLog.i(TXT_WELCOME_BACK, Dungeon.depth);
+            GLog.i(Game.getVar(R.string.GameScene_WelcomeBack), Dungeon.depth);
         } else {
-            GLog.i(TXT_WELCOME, Dungeon.depth);
+            GLog.i(Game.getVar(R.string.GameScene_Welcome), Dungeon.depth);
             Sample.INSTANCE.play(Assets.SND_DESCEND);
         }
         switch (level.getFeeling()) {
             case CHASM:
-                GLog.w(TXT_CHASM);
+                GLog.w(Game.getVar(R.string.GameScene_Chasm));
                 break;
             case WATER:
-                GLog.w(TXT_WATER);
+                GLog.w(Game.getVar(R.string.GameScene_Water));
                 break;
             case GRASS:
-                GLog.w(TXT_GRASS);
+                GLog.w(Game.getVar(R.string.GameScene_Grass));
                 break;
             default:
         }
 
         if (level instanceof RegularLevel
                 && ((RegularLevel) level).secretDoors > Random.IntRange(3, 4)) {
-            GLog.w(TXT_SECRETS);
+            GLog.w(Game.getVar(R.string.GameScene_Secrets));
         }
         if (Dungeon.nightMode && !Dungeon.bossLevel()) {
-            GLog.w(TXT_NIGHT_MODE);
+            GLog.w(Game.getVar(R.string.GameScene_NightMode));
         }
 
         busy = new BusyIndicator();

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/scenes/IntroScene.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/scenes/IntroScene.java
@@ -23,13 +23,11 @@ import com.watabou.pixeldungeon.windows.WndStory;
 
 public class IntroScene extends PixelScene {
 
-	private static final String TXT = Game.getVar(R.string.IntroScene_Txt);
-	
 	@Override
 	public void create() {
 		super.create();
 		
-		add( new WndStory( TXT ) {
+		add( new WndStory( Game.getVar(R.string.IntroScene_Txt) ) {
 			@Override
 			public void hide() {
 				super.hide();

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/scenes/RankingsScene.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/scenes/RankingsScene.java
@@ -49,12 +49,6 @@ public class RankingsScene extends PixelScene {
 
     private static final int recordsPerPage = 5;
 
-    private static final String TXT_TITLE    = Game.getVar(R.string.RankingsScene_Title);
-    private static final String TXT_TOTAL    = Game.getVar(R.string.RankingsScene_Total);
-    private static final String TXT_NO_GAMES = Game.getVar(R.string.RankingsScene_NoGames);
-
-    private static String TXT_NO_INFO = Game.getVar(R.string.RankingsScene_NoInfo);
-
     private static final float ROW_HEIGHT_L = 22;
     private static final float ROW_HEIGHT_P = 28;
 
@@ -90,7 +84,7 @@ public class RankingsScene extends PixelScene {
 
             float top = align(rowHeight / 2);
 
-            Text title = PixelScene.createText(TXT_TITLE, GuiProperties.titleFontSize());
+            Text title = PixelScene.createText(Game.getVar(R.string.RankingsScene_Title), GuiProperties.titleFontSize());
             title.hardlight(Window.TITLE_COLOR);
             title.x = align((w - title.width()) / 2);
             title.y = align(top - title.height() - GAP);
@@ -155,7 +149,7 @@ public class RankingsScene extends PixelScene {
 
             createRecords();
 
-            Text label = PixelScene.createText(TXT_TOTAL, GuiProperties.titleFontSize());
+            Text label = PixelScene.createText(Game.getVar(R.string.RankingsScene_Total), GuiProperties.titleFontSize());
             label.hardlight(DEFAULT_COLOR);
             add(label);
 
@@ -182,7 +176,7 @@ public class RankingsScene extends PixelScene {
 
         } else {
 
-            Text title = PixelScene.createText(TXT_NO_GAMES, GuiProperties.titleFontSize());
+            Text title = PixelScene.createText(Game.getVar(R.string.RankingsScene_NoGames), GuiProperties.titleFontSize());
             title.hardlight(DEFAULT_COLOR);
             title.x = align((w - title.width()) / 2);
             title.y = align((h - title.height()) / 2);
@@ -324,7 +318,7 @@ public class RankingsScene extends PixelScene {
             if (rec.gameFile.length() > 0) {
                 getParent().add(new WndRanking(rec.gameFile));
             } else {
-                getParent().add(new WndError(TXT_NO_INFO));
+                getParent().add(new WndError(Game.getVar(R.string.RankingsScene_NoInfo)));
             }
         }
     }

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/scenes/SurfaceScene.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/scenes/SurfaceScene.java
@@ -54,8 +54,6 @@ public class SurfaceScene extends PixelScene {
 	private static final int NSTARS		= 100;
 	private static final int NCLOUDS	= 5;
 	
-	private static final String TXT_GAME_OVER = Game.getVar(R.string.SurfaceScene_GameOver);
-	
 	private Camera viewport;
 	@Override
 	public void create() {
@@ -154,7 +152,7 @@ public class SurfaceScene extends PixelScene {
 		frame.y = vy - 9;
 		add( frame );
 		
-		RedButton gameOver = new RedButton( TXT_GAME_OVER ) {
+		RedButton gameOver = new RedButton( Game.getVar(R.string.SurfaceScene_GameOver) ) {
 			protected void onClick() {
 				Game.switchScene( TitleScene.class );
 			}

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/ui/QuickSlot.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/ui/QuickSlot.java
@@ -44,7 +44,6 @@ import static com.watabou.pixeldungeon.scenes.PixelScene.uiCamera;
 
 public class QuickSlot extends Button implements WndBag.Listener, WndHeroSpells.Listener {
 
-    private static final String TXT_SELECT_ITEM = Game.getVar(R.string.QuickSlot_SelectedItem);
     private static final String QUICKSLOT       = "quickslot";
 
     private static ArrayList<QuickSlot>     slots   = new ArrayList<>();
@@ -165,7 +164,7 @@ public class QuickSlot extends Button implements WndBag.Listener, WndHeroSpells.
             return;
         }
 
-        GameScene.selectItem(this, WndBag.Mode.QUICKSLOT, TXT_SELECT_ITEM);
+        GameScene.selectItem(this, WndBag.Mode.QUICKSLOT, Game.getVar(R.string.QuickSlot_SelectedItem));
     }
 
     @Override
@@ -173,7 +172,7 @@ public class QuickSlot extends Button implements WndBag.Listener, WndHeroSpells.
         if (Dungeon.hero.spellUser) {
             GameScene.selectSpell(this);
         } else {
-            GameScene.selectItem(this, WndBag.Mode.QUICKSLOT, TXT_SELECT_ITEM);
+            GameScene.selectItem(this, WndBag.Mode.QUICKSLOT, Game.getVar(R.string.QuickSlot_SelectedItem));
         }
         return true;
     }

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/windows/WndBlacksmith.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/windows/WndBlacksmith.java
@@ -48,10 +48,6 @@ public class WndBlacksmith extends Window {
 	private ItemButton btnItem2;
 	private RedButton btnReforge;
 	
-	private static final String TXT_PROMPT  = Game.getVar(R.string.WndBlacksmith_Prompt);
-	private static final String TXT_SELECT  = Game.getVar(R.string.WndBlacksmith_Select);
-	private static final String TXT_REFORGE = Game.getVar(R.string.WndBlacksmith_Reforge);
-	
 	public WndBlacksmith( Blacksmith troll, Hero hero ) {
 		
 		super();
@@ -62,7 +58,7 @@ public class WndBlacksmith extends Window {
 		titlebar.setRect( 0, 0, WIDTH, 0 );
 		add( titlebar );
 		
-		Text message = PixelScene.createMultiline( TXT_PROMPT, GuiProperties.regularFontSize());
+		Text message = PixelScene.createMultiline( Game.getVar(R.string.WndBlacksmith_Prompt), GuiProperties.regularFontSize());
 		message.maxWidth(WIDTH);
 		message.y = titlebar.bottom() + GAP;
 		add( message );
@@ -71,7 +67,7 @@ public class WndBlacksmith extends Window {
 			@Override
 			protected void onClick() {
 				btnPressed = btnItem1;
-				GameScene.selectItem( itemSelector, WndBag.Mode.UPGRADEABLE, TXT_SELECT );
+				GameScene.selectItem( itemSelector, WndBag.Mode.UPGRADEABLE, Game.getVar(R.string.WndBlacksmith_Select) );
 			}
 		};
 		btnItem1.setRect( (WIDTH - BTN_GAP) / 2 - BTN_SIZE, message.y + message.height() + BTN_GAP, BTN_SIZE, BTN_SIZE );
@@ -81,13 +77,13 @@ public class WndBlacksmith extends Window {
 			@Override
 			protected void onClick() {
 				btnPressed = btnItem2;
-				GameScene.selectItem( itemSelector, WndBag.Mode.UPGRADEABLE, TXT_SELECT );
+				GameScene.selectItem( itemSelector, WndBag.Mode.UPGRADEABLE, Game.getVar(R.string.WndBlacksmith_Select) );
 			}
 		};
 		btnItem2.setRect( btnItem1.right() + BTN_GAP, btnItem1.top(), BTN_SIZE, BTN_SIZE );
 		add( btnItem2 );
 		
-		btnReforge = new RedButton( TXT_REFORGE ) {
+		btnReforge = new RedButton( Game.getVar(R.string.WndBlacksmith_Reforge) ) {
 			@Override
 			protected void onClick() {
 				Blacksmith.upgrade( btnItem1.item, btnItem2.item );

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/windows/WndCatalogus.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/windows/WndCatalogus.java
@@ -41,10 +41,6 @@ public class WndCatalogus extends WndTabbed {
 
 	private static final int ITEM_HEIGHT = 18;
 
-	private static final String TXT_POTIONS = Game.getVar(R.string.WndCatalogus_Potions);
-	private static final String TXT_SCROLLS = Game.getVar(R.string.WndCatalogus_Scrolls);
-	private static final String TXT_TITLE   = Game.getVar(R.string.WndCatalogus_Title);
-
 	private Text       txtTitle;
 	private ScrollPane list;
 
@@ -58,7 +54,7 @@ public class WndCatalogus extends WndTabbed {
 
 		resize(WndHelper.getLimitedWidth(120), WndHelper.getFullscreenHeight() - tabHeight() - MARGIN);
 
-		txtTitle = PixelScene.createText(TXT_TITLE, GuiProperties.titleFontSize());
+		txtTitle = PixelScene.createText(Game.getVar(R.string.WndCatalogus_Title), GuiProperties.titleFontSize());
 		txtTitle.hardlight(Window.TITLE_COLOR);
 		add(txtTitle);
 
@@ -69,14 +65,14 @@ public class WndCatalogus extends WndTabbed {
 
 		boolean showPotions = WndCatalogus.showPotions;
 		Tab[] tabs = {
-				new LabeledTab(this, TXT_POTIONS) {
+				new LabeledTab(this, Game.getVar(R.string.WndCatalogus_Potions)) {
 					public void select(boolean value) {
 						super.select(value);
 						WndCatalogus.showPotions = value;
 						updateList();
 					}
 				},
-				new LabeledTab(this, TXT_SCROLLS) {
+				new LabeledTab(this, Game.getVar(R.string.WndCatalogus_Scrolls)) {
 					public void select(boolean value) {
 						super.select(value);
 						WndCatalogus.showPotions = !value;
@@ -94,7 +90,8 @@ public class WndCatalogus extends WndTabbed {
 
 	private void updateList() {
 
-		txtTitle.text(Utils.format(TXT_TITLE, showPotions ? TXT_POTIONS : TXT_SCROLLS));
+		txtTitle.text(Utils.format(Game.getVar(R.string.WndCatalogus_Title), showPotions ?
+				Game.getVar(R.string.WndCatalogus_Potions) : Game.getVar(R.string.WndCatalogus_Scrolls)));
 		txtTitle.x = PixelScene.align(PixelScene.uiCamera, (width - txtTitle.width()) / 2);
 
 		items.clear();

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/windows/WndChooseWay.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/windows/WndChooseWay.java
@@ -36,12 +36,6 @@ import com.watabou.pixeldungeon.utils.Utils;
 
 public class WndChooseWay extends Window {
 	
-	private static final String TXT_MESSAGE	= Game.getVar(R.string.WndChooseWay_Message);
-	private static final String TXT_CANCEL	= Game.getVar(R.string.WndChooseWay_Cancel);
-	private static final String TXT_BREAK_SPELL	= Game.getVar(R.string.BlackSkullOfMastery_RemainHumanDesc);
-	private static final String TXT_BREAK_SPELL_BTN	= Game.getVar(R.string.BlackSkullOfMastery_Necromancer);
-	private static final String TXT_BLACKSKULL_TITLE	= Game.getVar(R.string.BlackSkullOfMastery_Title);
-
 	private static final int WIDTH		= 120;
 	private static final int BTN_HEIGHT	= 18;
 
@@ -61,9 +55,10 @@ public class WndChooseWay extends Window {
 			desc = desc + "\n\n" + way2.desc();
 		}
 		if (way1 == HeroSubClass.LICH){
-			desc = TXT_BLACKSKULL_TITLE + "\n\n" + desc + "\n\n" + TXT_BREAK_SPELL;
+			desc = Game.getVar(R.string.BlackSkullOfMastery_Title) + "\n\n"
+					+ desc + "\n\n" + Game.getVar(R.string.BlackSkullOfMastery_RemainHumanDesc);
 		}
-		desc = desc + "\n\n" + TXT_MESSAGE;
+		desc = desc + "\n\n" + Game.getVar(R.string.WndChooseWay_Message);
 		return desc;
 	}
 
@@ -122,7 +117,7 @@ public class WndChooseWay extends Window {
 			btnBreakSpell(btnWay1);
 		}
 
-		RedButton btnCancel = new RedButton( TXT_CANCEL ) {
+		RedButton btnCancel = new RedButton( Game.getVar(R.string.WndChooseWay_Cancel) ) {
 			@Override
 			protected void onClick() {
 				hide();
@@ -135,7 +130,7 @@ public class WndChooseWay extends Window {
 	}
 
 	private void btnBreakSpell(RedButton btnWay1){
-		RedButton btnWay2 = new RedButton( Utils.capitalize( TXT_BREAK_SPELL_BTN ) ) {
+		RedButton btnWay2 = new RedButton( Utils.capitalize( Game.getVar(R.string.BlackSkullOfMastery_Necromancer) ) ) {
 			@Override
 			protected void onClick() {
 				hide();

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/windows/WndClass.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/windows/WndClass.java
@@ -33,8 +33,6 @@ import com.watabou.pixeldungeon.windows.elements.Tab;
 
 public class WndClass extends WndTabbed {
 
-	private static final String TXT_MASTERY = Game.getVar(R.string.WndClass_Mastery);
-
 	private static final int WIDTH_P = 112;
 	private static final int WIDTH_L = 160;
 
@@ -63,7 +61,7 @@ public class WndClass extends WndTabbed {
 			MasteryTab tabMastery = new MasteryTab();
 			add(tabMastery);
 
-			tab = new RankingTab(this, TXT_MASTERY, tabMastery);
+			tab = new RankingTab(this, Game.getVar(R.string.WndClass_Mastery), tabMastery);
 			tab.setSize(TAB_WIDTH, tabHeight());
 			add(tab);
 

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/windows/WndError.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/windows/WndError.java
@@ -23,10 +23,8 @@ import com.watabou.pixeldungeon.ui.Icons;
 
 public class WndError extends WndTitledMessage {
 
-	private static final String TXT_TITLE = Game.getVar(R.string.WndError_Title);
-	
 	public WndError( String message ) {
-		super( Icons.WARNING.get(), TXT_TITLE, message );
+		super( Icons.WARNING.get(), Game.getVar(R.string.WndError_Title), message );
 	}
 
 }

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/windows/WndImp.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/windows/WndImp.java
@@ -35,9 +35,6 @@ import com.watabou.pixeldungeon.utils.Utils;
 
 public class WndImp extends Window {
 
-	private static final String TXT_MESSAGE	= Game.getVar(R.string.WndImp_Message);
-	private static final String TXT_REWARD  = Game.getVar(R.string.WndImp_Reward);
-
 	private static final int WIDTH		= 120;
 	private static final int BTN_HEIGHT	= 18;
 
@@ -51,12 +48,12 @@ public class WndImp extends Window {
 		titlebar.setRect( 0, 0, WIDTH, 0 );
 		add( titlebar );
 		
-		Text message = PixelScene.createMultiline( TXT_MESSAGE, GuiProperties.regularFontSize() );
+		Text message = PixelScene.createMultiline( Game.getVar(R.string.WndImp_Message), GuiProperties.regularFontSize() );
 		message.maxWidth(WIDTH);
 		message.y = titlebar.bottom() + GAP;
 		add( message );
 		
-		RedButton btnReward = new RedButton( TXT_REWARD ) {
+		RedButton btnReward = new RedButton( Game.getVar(R.string.WndImp_Reward) ) {
 			@Override
 			protected void onClick() {
 				takeReward( imp, tokens, Imp.Quest.reward );

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/windows/WndInfoCell.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/windows/WndInfoCell.java
@@ -37,8 +37,6 @@ public class WndInfoCell extends Window {
 
 	private static final int WIDTH = 120;
 	
-	private static final String TXT_NOTHING	= Game.getVar(R.string.WndInfoCell_Nothing);
-	
 	public WndInfoCell( int cell ) {
 		
 		super();
@@ -97,7 +95,7 @@ public class WndInfoCell extends Window {
 			}
 		}
 
-		info.text( desc.length() > 0 ? desc.toString() : TXT_NOTHING );
+		info.text( desc.length() > 0 ? desc.toString() : Game.getVar(R.string.WndInfoCell_Nothing) );
 		info.maxWidth(WIDTH);
 		info.x = titlebar.left();
 		info.y = yPos + GAP;

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/windows/WndInfoItem.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/windows/WndInfoItem.java
@@ -30,17 +30,6 @@ import com.watabou.pixeldungeon.windows.elements.GenericInfo;
 
 public class WndInfoItem extends Window {
 
-	private static final String TXT_CHEST			= Game.getVar(R.string.WndInfoItem_Chest);
-	private static final String TXT_LOCKED_CHEST	= Game.getVar(R.string.WndInfoItem_LockedChest);
-	private static final String TXT_CRYSTAL_CHEST	= Game.getVar(R.string.WndInfoItem_CrystalChest);
-	private static final String TXT_TOMB			= Game.getVar(R.string.WndInfoItem_Tomb);
-	private static final String TXT_SKELETON		= Game.getVar(R.string.WndInfoItem_Skeleton);
-	private static final String TXT_WONT_KNOW		= Game.getVar(R.string.WndInfoItem_WontKnow);
-	private static final String TXT_NEED_KEY		= TXT_WONT_KNOW +" "+ Game.getVar(R.string.WndInfoItem_NeedKey);
-	private static final String TXT_INSIDE			= Game.getVar(R.string.WndInfoItem_Inside);
-	private static final String TXT_OWNER           = Game.getVar(R.string.WndInfoItem_Owner);
-	private static final String TXT_REMAINS	        = Game.getVar(R.string.WndInfoItem_Remains);
-	
 	public WndInfoItem( Heap heap ) {
 		
 		super();
@@ -63,20 +52,20 @@ public class WndInfoItem extends Window {
 			String info;
 			
 			if (heap.type == Type.CHEST || heap.type == Type.MIMIC) {
-				title = TXT_CHEST;
-				info = TXT_WONT_KNOW;
+				title = Game.getVar(R.string.WndInfoItem_Chest);
+				info = Game.getVar(R.string.WndInfoItem_WontKnow);
 			} else if (heap.type == Type.TOMB) {
-				title = TXT_TOMB;
-				info = TXT_OWNER;
+				title = Game.getVar(R.string.WndInfoItem_Tomb);
+				info = Game.getVar(R.string.WndInfoItem_Owner);
 			} else if (heap.type == Type.SKELETON) {
-				title = TXT_SKELETON;
-				info = TXT_REMAINS;
+				title = Game.getVar(R.string.WndInfoItem_Skeleton);
+				info = Game.getVar(R.string.WndInfoItem_Remains);
 			} else if (heap.type == Type.CRYSTAL_CHEST) {
-				title = TXT_CRYSTAL_CHEST;
-				info = Utils.format( TXT_INSIDE, Utils.indefinite( heap.peek().name() ) );
+				title = Game.getVar(R.string.WndInfoItem_CrystalChest);
+				info = Utils.format( Game.getVar(R.string.WndInfoItem_Inside), Utils.indefinite( heap.peek().name() ) );
 			} else {
-				title = TXT_LOCKED_CHEST;
-				info = TXT_NEED_KEY;
+				title = Game.getVar(R.string.WndInfoItem_LockedChest);
+				info = Game.getVar(R.string.WndInfoItem_WontKnow) +" "+ Game.getVar(R.string.WndInfoItem_NeedKey);
 			}
 			
 			fillFields( heap, TITLE_COLOR, title, info );

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/windows/WndJournal.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/windows/WndJournal.java
@@ -40,10 +40,6 @@ public class WndJournal extends WndTabbed {
 
     private static final int LEVEL_ITEM_HEIGHT = 18;    // Height of a level entry
 
-    private static final String TXT_TITLE   = Game.getVar(R.string.WndJournal_Title);
-    private static final String TXT_LEVELS  = Game.getVar(R.string.WndJournal_Levels);
-    private static final String TXT_LOGBOOK = Game.getVar(R.string.WndJournal_Logbook);
-
     private ScrollPane list;
 
     public WndJournal() {
@@ -52,7 +48,7 @@ public class WndJournal extends WndTabbed {
 
         resize(WndHelper.getLimitedWidth(120), WndHelper.getFullscreenHeight() - tabHeight() - MARGIN);
 
-        Text txtTitle = PixelScene.createText(TXT_TITLE, GuiProperties.titleFontSize());
+        Text txtTitle = PixelScene.createText(Game.getVar(R.string.WndJournal_Title), GuiProperties.titleFontSize());
         txtTitle.hardlight(Window.TITLE_COLOR);
         txtTitle.x = PixelScene.align(PixelScene.uiCamera, (width - txtTitle.width()) / 2);
         add(txtTitle);
@@ -178,7 +174,7 @@ public class WndJournal extends WndTabbed {
 
     private class JournalTab extends ContentTab {
         JournalTab() {
-            super(WndJournal.this, WndJournal.TXT_LEVELS);
+            super(WndJournal.this, Game.getVar(R.string.WndJournal_Levels));
         }
 
         @Override
@@ -202,7 +198,7 @@ public class WndJournal extends WndTabbed {
 
     private class LogbookTab extends ContentTab {
         LogbookTab() {
-            super(WndJournal.this, WndJournal.TXT_LOGBOOK);
+            super(WndJournal.this, Game.getVar(R.string.WndJournal_Logbook));
         }
 
         @Override

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/windows/WndRanking.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/windows/WndRanking.java
@@ -53,12 +53,6 @@ import java.util.Locale;
 
 public class WndRanking extends WndTabbed {
 	
-	private static final String TXT_ERROR   = Game.getVar(R.string.WndRanking_Error);
-	
-	private static final String TXT_STATS	= Game.getVar(R.string.WndRanking_Stats);
-	private static final String TXT_ITEMS	= Game.getVar(R.string.WndRanking_Items);
-	private static final String TXT_BADGES	= Game.getVar(R.string.WndRanking_Badges);
-
 	private static final int WIDTH			= 112;
 	private static final int HEIGHT			= 144;
 	
@@ -81,7 +75,7 @@ public class WndRanking extends WndTabbed {
 					Badges.loadGlobal();
 					Dungeon.loadGameForRankings( gameFile );
 				} catch (Exception e ) {
-					error = TXT_ERROR + "->" +e.getMessage();
+					error = Game.getVar(R.string.WndRanking_Error) + "->" +e.getMessage();
 					GLog.i(error);
 				}
 			}
@@ -107,7 +101,7 @@ public class WndRanking extends WndTabbed {
 				createControls();
 			} else {
 				hide();
-				Game.scene().add( new WndError( TXT_ERROR ) );
+				Game.scene().add( new WndError( Game.getVar(R.string.WndRanking_Error) ) );
 			}
 		}
 	}
@@ -115,7 +109,9 @@ public class WndRanking extends WndTabbed {
 	private void createControls() {
 		
 		String[] labels = 
-			{TXT_STATS, TXT_ITEMS, TXT_BADGES};
+			{ Game.getVar(R.string.WndRanking_Stats),
+					Game.getVar(R.string.WndRanking_Items),
+					Game.getVar(R.string.WndRanking_Badges) };
 		Group[] pages = 
 			{new StatsTab(), new ItemsTab(), new BadgesTab()};
 		

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/windows/WndResurrect.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/windows/WndResurrect.java
@@ -33,11 +33,7 @@ import com.watabou.pixeldungeon.ui.Window;
 import com.watabou.pixeldungeon.utils.Utils;
 
 public class WndResurrect extends Window {
-	
-	private static final String TXT_MESSAGE	= Game.getVar(R.string.WndResurrect_Message);
-	private static final String TXT_YES		= Game.getVar(R.string.WndResurrect_Yes);
-	private static final String TXT_NO		= Game.getVar(R.string.WndResurrect_No);
-	
+
 	private static final int WIDTH		= 120;
 	private static final int BTN_HEIGHT	= 18;
 
@@ -62,12 +58,12 @@ public class WndResurrect extends Window {
 		titlebar.setRect( 0, 0, WIDTH, 0 );
 		add( titlebar );
 		
-		Text message = PixelScene.createMultiline( TXT_MESSAGE, GuiProperties.regularFontSize() );
+		Text message = PixelScene.createMultiline( Game.getVar(R.string.WndResurrect_Message), GuiProperties.regularFontSize() );
 		message.maxWidth(WIDTH);
 		message.y = titlebar.bottom() + GAP;
 		add( message );
 		
-		RedButton btnYes = new RedButton( TXT_YES ) {
+		RedButton btnYes = new RedButton( Game.getVar(R.string.WndResurrect_Yes) ) {
 			@Override
 			protected void onClick() {
 				hide();
@@ -81,7 +77,7 @@ public class WndResurrect extends Window {
 		btnYes.setRect( 0, message.y + message.height() + GAP, WIDTH, BTN_HEIGHT );
 		add( btnYes );
 		
-		RedButton btnNo = new RedButton( TXT_NO ) {
+		RedButton btnNo = new RedButton( Game.getVar(R.string.WndResurrect_No) ) {
 			@Override
 			protected void onClick() {
 				hide();

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/windows/WndSadGhost.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/windows/WndSadGhost.java
@@ -35,12 +35,6 @@ import com.watabou.pixeldungeon.utils.Utils;
 
 public class WndSadGhost extends Window {
 	
-	private static final String TXT_ROSE     = Game.getVar(R.string.WndSadGhost_Rose);
-	private static final String TXT_RAT      = Game.getVar(R.string.WndSadGhost_Rat);
-	private static final String TXT_WEAPON   = Game.getVar(R.string.WndSadGhost_Wepon);
-	private static final String TXT_ARMOR    = Game.getVar(R.string.WndSadGhost_Armor);
-	private static final String TXT_FAREWELL = Game.getVar(R.string.WndSadGhost_Farewell);
-	
 	private static final int WIDTH		= 120;
 	private static final int BTN_HEIGHT	= 18;
 	
@@ -54,12 +48,15 @@ public class WndSadGhost extends Window {
 		titlebar.setRect( 0, 0, WIDTH, 0 );
 		add( titlebar );
 		
-		Text message = PixelScene.createMultiline( item instanceof DriedRose ? TXT_ROSE : TXT_RAT, GuiProperties.regularFontSize() );
+		Text message = PixelScene.createMultiline(
+				item instanceof DriedRose ? Game.getVar(R.string.WndSadGhost_Rose) : Game.getVar(R.string.WndSadGhost_Rat),
+				GuiProperties.regularFontSize()
+		);
 		message.maxWidth(WIDTH);
 		message.y = titlebar.bottom() + GAP;
 		add( message );
 		
-		RedButton btnWeapon = new RedButton( TXT_WEAPON ) {
+		RedButton btnWeapon = new RedButton( Game.getVar(R.string.WndSadGhost_Wepon) ) {
 			@Override
 			protected void onClick() {
 				selectReward( ghost, item, Ghost.Quest.weapon );
@@ -68,7 +65,7 @@ public class WndSadGhost extends Window {
 		btnWeapon.setRect( 0, message.y + message.height() + GAP, WIDTH, BTN_HEIGHT );
 		add( btnWeapon );
 		
-		RedButton btnArmor = new RedButton( TXT_ARMOR ) {
+		RedButton btnArmor = new RedButton( Game.getVar(R.string.WndSadGhost_Armor) ) {
 			@Override
 			protected void onClick() {
 				selectReward( ghost, item, Ghost.Quest.armor );
@@ -91,7 +88,7 @@ public class WndSadGhost extends Window {
 			Dungeon.level.drop( reward, ghost.getPos() ).sprite.drop();
 		}
 		
-		ghost.say( TXT_FAREWELL );
+		ghost.say( Game.getVar(R.string.WndSadGhost_Farewell) );
 		ghost.die( null );
 		
 		Ghost.Quest.complete();

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/windows/WndTradeItem.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/windows/WndTradeItem.java
@@ -44,16 +44,6 @@ public class WndTradeItem extends Window {
 	private static final int WIDTH		= 120;
 	private static final int BTN_HEIGHT	= 18;
 	
-	private static final String TXT_SALE     = Game.getVar(R.string.WndTradeItem_Sale);
-	private static final String TXT_BUY      = Game.getVar(R.string.WndTradeItem_Buy);
-	private static final String TXT_SELL     = Game.getVar(R.string.WndTradeItem_Sell);
-	private static final String TXT_SELL_1   = Game.getVar(R.string.WndTradeItem_Sell1);
-	private static final String TXT_SELL_ALL = Game.getVar(R.string.WndTradeItem_SellAll);
-	private static final String TXT_CANCEL   = Game.getVar(R.string.WndTradeItem_Cancel);
-	
-	private static final String TXT_SOLD     = Game.getVar(R.string.WndTradeItem_Sold);
-	private static final String TXT_BOUGHT   = Game.getVar(R.string.WndTradeItem_Bought);
-	
 	private WndBag owner;
 	
 	public WndTradeItem( final Item item, WndBag owner ) {
@@ -66,7 +56,7 @@ public class WndTradeItem extends Window {
 		
 		if (item.quantity() == 1) {
 			
-			RedButton btnSell = new RedButton( Utils.format( TXT_SELL, item.price() ) ) {
+			RedButton btnSell = new RedButton( Utils.format( Game.getVar(R.string.WndTradeItem_Sell), item.price() ) ) {
 				@Override
 				protected void onClick() {
 					sell( item );
@@ -81,7 +71,7 @@ public class WndTradeItem extends Window {
 		} else {
 			
 			int priceAll= item.price();
-			RedButton btnSell1 = new RedButton( Utils.format( TXT_SELL_1, priceAll / item.quantity() ) ) {
+			RedButton btnSell1 = new RedButton( Utils.format( Game.getVar(R.string.WndTradeItem_Sell1), priceAll / item.quantity() ) ) {
 				@Override
 				protected void onClick() {
 					sellOne( item );
@@ -90,7 +80,7 @@ public class WndTradeItem extends Window {
 			};
 			btnSell1.setRect( 0, pos + GAP, WIDTH, BTN_HEIGHT );
 			add( btnSell1 );
-			RedButton btnSellAll = new RedButton( Utils.format( TXT_SELL_ALL, priceAll ) ) {
+			RedButton btnSellAll = new RedButton( Utils.format( Game.getVar(R.string.WndTradeItem_SellAll), priceAll ) ) {
 				@Override
 				protected void onClick() {
 					sell( item );
@@ -104,7 +94,7 @@ public class WndTradeItem extends Window {
 			
 		}
 		
-		RedButton btnCancel = new RedButton( TXT_CANCEL ) {
+		RedButton btnCancel = new RedButton( Game.getVar(R.string.WndTradeItem_Cancel) ) {
 			@Override
 			protected void onClick() {
 				hide();
@@ -128,7 +118,7 @@ public class WndTradeItem extends Window {
 		
 		if (canBuy) {
 			
-			RedButton btnBuy = new RedButton( Utils.format( TXT_BUY, price ) ) {
+			RedButton btnBuy = new RedButton( Utils.format( Game.getVar(R.string.WndTradeItem_Buy), price ) ) {
 				@Override
 				protected void onClick() {
 					hide();
@@ -139,7 +129,7 @@ public class WndTradeItem extends Window {
 			btnBuy.enable( price <= Dungeon.gold());
 			add( btnBuy );
 			
-			RedButton btnCancel = new RedButton( TXT_CANCEL ) {
+			RedButton btnCancel = new RedButton( Game.getVar(R.string.WndTradeItem_Cancel) ) {
 				@Override
 				protected void onClick() {
 					hide();
@@ -174,7 +164,7 @@ public class WndTradeItem extends Window {
 		IconTitle titlebar = new IconTitle();
 		titlebar.icon( new ItemSprite( item ) );
 		titlebar.label( forSale ? 
-			Utils.format( TXT_SALE, item.toString(), price( item ) ) : 
+			Utils.format( Game.getVar(R.string.WndTradeItem_Sale), item.toString(), price( item ) ) :
 			Utils.capitalize( item.toString() ) );
 		titlebar.setRect( 0, 0, WIDTH, 0 );
 		add( titlebar );
@@ -208,7 +198,7 @@ public class WndTradeItem extends Window {
 		int price = item.price();
 		
 		new Gold( price ).doPickUp( hero );
-		GLog.i( TXT_SOLD, item.name(), price );
+		GLog.i( Game.getVar(R.string.WndTradeItem_Sold), item.name(), price );
 
 		placeItemInShop(item);
 	}
@@ -232,7 +222,7 @@ public class WndTradeItem extends Window {
 			int price = item.price();
 			
 			new Gold( price ).doPickUp( hero );
-			GLog.i( TXT_SOLD, item.name(), price );
+			GLog.i( Game.getVar(R.string.WndTradeItem_Sold), item.name(), price );
 
 			placeItemInShop(item);
 		}
@@ -255,7 +245,7 @@ public class WndTradeItem extends Window {
 		int price = price( item );
 		Dungeon.gold(Dungeon.gold() - price);
 		
-		GLog.i( TXT_BOUGHT, item.name(), price );
+		GLog.i( Game.getVar(R.string.WndTradeItem_Bought), item.name(), price );
 		
 		if (!item.doPickUp( hero )) {
 			Dungeon.level.drop( item, heap.pos ).sprite.drop();

--- a/PixelDungeon/src/main/java/com/watabou/pixeldungeon/windows/WndWandmaker.java
+++ b/PixelDungeon/src/main/java/com/watabou/pixeldungeon/windows/WndWandmaker.java
@@ -35,12 +35,6 @@ import com.watabou.pixeldungeon.utils.Utils;
 
 public class WndWandmaker extends Window {
 	
-	private static final String TXT_MESSAGE	   = Game.getVar(R.string.WndWandmaker_Message);
-	private static final String TXT_BATTLE     = Game.getVar(R.string.WndWandmaker_Battle);
-	private static final String TXT_NON_BATTLE = Game.getVar(R.string.WndWandmaker_NonBattle);
-
-	private static final String TXT_FARAWELL   = Game.getVar(R.string.WndWandmaker_Farawell);
-	
 	private static final int WIDTH		= 120;
 	private static final int BTN_HEIGHT	= 18;
 	
@@ -54,12 +48,12 @@ public class WndWandmaker extends Window {
 		titlebar.setRect( 0, 0, WIDTH, 0 );
 		add( titlebar );
 		
-		Text message = PixelScene.createMultiline( TXT_MESSAGE, GuiProperties.regularFontSize() );
+		Text message = PixelScene.createMultiline( Game.getVar(R.string.WndWandmaker_Message), GuiProperties.regularFontSize() );
 		message.maxWidth(WIDTH);
 		message.y = titlebar.bottom() + GAP;
 		add( message );
 		
-		RedButton btnBattle = new RedButton( TXT_BATTLE ) {
+		RedButton btnBattle = new RedButton( Game.getVar(R.string.WndWandmaker_Battle) ) {
 			@Override
 			protected void onClick() {
 				selectReward( wandmaker, item, WandMaker.makeBattleWand() );
@@ -68,7 +62,7 @@ public class WndWandmaker extends Window {
 		btnBattle.setRect( 0, message.y + message.height() + GAP, WIDTH, BTN_HEIGHT );
 		add( btnBattle );
 		
-		RedButton btnNonBattle = new RedButton( TXT_NON_BATTLE ) {
+		RedButton btnNonBattle = new RedButton( Game.getVar(R.string.WndWandmaker_NonBattle) ) {
 			@Override
 			protected void onClick() {
 				selectReward( wandmaker, item, WandMaker.makeNonBattleWand() );
@@ -92,7 +86,7 @@ public class WndWandmaker extends Window {
 			Dungeon.level.drop( reward, wandmaker.getPos() ).sprite.drop();
 		}
 		
-		wandmaker.say(Utils.format( TXT_FARAWELL, Dungeon.hero.className() ) );
+		wandmaker.say(Utils.format( Game.getVar(R.string.WndWandmaker_Farawell), Dungeon.hero.className() ) );
 		wandmaker.destroy();
 		
 		wandmaker.getSprite().die();


### PR DESCRIPTION
Moving on with #37.

In this case please take a look at the following commits - 4ae86a0, 56a3673, 4d21eff - all these take a protected string field and substitute is with the `Game.getVar()` call. My issue is not with this fix, but with the current behavior. Currently, for example in `BattleMageArmor.java`, there is a check for whether the sub class is `BATTLEMAGE`, and if not, it will log "Only mages can use this armor!". This is not the right response though, since it might be a mage (but not a battle mage) that's trying the armor on. Take note that I'm not familiar with the sub-classes at all and they might not even be in use currently, then it's not a problem.

Another thing - there are non-static, but similar fields, for example [here](https://github.com/NYRDS/pixel-dungeon-remix/blob/a40508ce5f3c743b3fd3d35f5f8308743ee66148/PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/Weightstone.java#L123). These should go as well, correct? Or they are OK, since they are created together with the object?