### PR TITLE
Remove string field from Drink and ManaPotion

### DIFF
--- a/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/items/drinks/Drink.java
+++ b/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/items/drinks/Drink.java
@@ -13,8 +13,6 @@ abstract public class Drink extends Item {
 	
 	public static final String AC_DRINK = "Drink_ACDrink";
 
-	public String message 	= Game.getVar(R.string.Drink_Message);
-	
 	{
 		stackable = true;
 		defaultAction = AC_DRINK;

--- a/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/items/drinks/ManaPotion.java
+++ b/PixelDungeon/src/main/java/com/nyrds/pixeldungeon/items/drinks/ManaPotion.java
@@ -1,5 +1,7 @@
 package com.nyrds.pixeldungeon.items.drinks;
 
+import com.nyrds.pixeldungeon.ml.R;
+import com.watabou.noosa.Game;
 import com.watabou.noosa.audio.Sample;
 import com.watabou.pixeldungeon.Assets;
 import com.watabou.pixeldungeon.actors.hero.Hero;
@@ -22,7 +24,7 @@ public class ManaPotion extends Drink {
 	public void execute(Hero hero, String action ) {
 		if (action.equals( AC_DRINK )) {
 			detach( hero.belongings.backpack );
-			GLog.i( message );
+			GLog.i( Game.getVar(R.string.Drink_Message) );
 
 			hero.setSoulPoints(hero.getSoulPoints() + hero.getSoulPointsMax()/3);
 			hero.getSprite().operate( hero.getPos() );


### PR DESCRIPTION
Another one apparently missed.

While at it, I found some more candidates for this cleanup, but I'm not sure how to deal with them or if we even should deal with them. Some of these are used in a complex way, others are being written to:

```
PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mechanics/spells/Spell.java:    protected String name = getClassParam("Name", Game.getVar(R.string.Item_Name));
PixelDungeon/src/main/java/com/nyrds/pixeldungeon/mechanics/spells/Spell.java:    protected String info = getClassParam("Info", Game.getVar(R.string.Item_Info));
PixelDungeon/src/main/java/com/watabou/pixeldungeon/actors/Char.java:   protected String name           = Game.getVar(R.string.Char_Name);
PixelDungeon/src/main/java/com/watabou/pixeldungeon/actors/Char.java:   protected String name_objective = Game.getVar(R.string.Char_Name_Objective);
PixelDungeon/src/main/java/com/watabou/pixeldungeon/actors/Char.java:   protected String description = Game.getVar(R.string.Mob_Desc);
PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/food/Food.java:       public String message = Game.getVar(R.string.Food_Message);
PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/Item.java:    protected String name = getClassParam("Name", Game.getVar(R.string.Item_Name), false);
PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/Item.java:    protected String info = getClassParam("Info", Game.getVar(R.string.Item_Info), false);
PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/Item.java:    protected String info2 = getClassParam("Info2", Game.getVar(R.string.Item_Info2), false);
PixelDungeon/src/main/java/com/watabou/pixeldungeon/items/scrolls/InventoryScroll.java: protected String inventoryTitle = Game.getVar(R.string.InventoryScroll_Title);
```

You should probably check these out just to be sure.